### PR TITLE
refactor: remove icon and pacman display options

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -225,10 +225,7 @@ show_delta=true
 # Show session_id in status line
 show_session=true
 
-# Activity icon mode: standard, pacman, or off
-icon_mode=standard
-
-# Disable rotating text and icon animations
+# Disable rotating text animations
 reduced_motion=false
 EOF
     echo -e "${GREEN}✓${RESET} Created config file: $CONFIG_FILE"

--- a/scripts/context-stats.sh
+++ b/scripts/context-stats.sh
@@ -57,7 +57,6 @@ COLOR_ENABLED=true
 TOKEN_DETAIL_ENABLED=true
 WATCH_MODE=true
 WATCH_INTERVAL=2
-ICON_MODE="standard"
 REDUCED_MOTION=false
 CYCLE_COUNTER=0
 
@@ -346,38 +345,6 @@ get_activity_tier() {
     fi
 }
 
-# Get icon for activity tier
-get_activity_icon() {
-    local tier=$1
-    local mode=$2
-
-    if [ "$mode" = "off" ]; then
-        echo ""
-        return
-    fi
-
-    if [ "$mode" = "pacman" ]; then
-        case "$tier" in
-            idle)   echo "·" ;;
-            low)    echo "ᗧ···" ;;
-            medium) echo "ᗧ○·●" ;;
-            high)   echo "ᗧ●●●" ;;
-            spike)  echo "👻ᗧ●●●" ;;
-            *)      echo "·" ;;
-        esac
-    else
-        # Standard mode
-        case "$tier" in
-            idle)   echo "○" ;;
-            low)    echo "◐" ;;
-            medium) echo "◉" ;;
-            high)   echo "⚡" ;;
-            spike)  echo "💥" ;;
-            *)      echo "○" ;;
-        esac
-    fi
-}
-
 # Get text label for tier
 get_tier_label() {
     local tier=$1
@@ -389,52 +356,6 @@ get_tier_label() {
         spike)  echo "Spike!" ;;
         *)      echo "Idle" ;;
     esac
-}
-
-# Render Pacman meter bar
-render_pacman_meter() {
-    local usage_pct=$1
-    local tier=$2
-    local width=${3:-30}
-
-    # Clamp
-    [ "$usage_pct" -lt 0 ] && usage_pct=0
-    [ "$usage_pct" -gt 100 ] && usage_pct=100
-    [ "$width" -lt 10 ] && width=10
-
-    # Pacman position
-    local pacman_pos=$((usage_pct * (width - 1) / 100))
-    [ "$pacman_pos" -lt 0 ] && pacman_pos=0
-    [ "$pacman_pos" -ge "$width" ] && pacman_pos=$((width - 1))
-
-    # Choose pacman character
-    local pacman
-    if [ "$usage_pct" -gt 80 ]; then
-        pacman="ᗤ"
-    else
-        pacman="ᗧ"
-    fi
-
-    # Ghost on spike
-    local ghost=" "
-    [ "$tier" = "spike" ] && ghost="👻"
-
-    # Build bar
-    local eaten=""
-    local remaining=""
-    local i=0
-    while [ "$i" -lt "$pacman_pos" ]; do
-        eaten="${eaten}░"
-        i=$((i + 1))
-    done
-    i=0
-    local rem_count=$((width - pacman_pos - 1))
-    while [ "$i" -lt "$rem_count" ]; do
-        remaining="${remaining}█"
-        i=$((i + 1))
-    done
-
-    echo "${eaten}${pacman}${remaining}${ghost} ${usage_pct}% used"
 }
 
 # === DATA FUNCTIONS ===
@@ -923,16 +844,6 @@ render_summary() {
         fi
         # Context remaining (before status)
         printf '  %b%-20s%b %s/%s (%s%%)\n' "${status_color}" "Context Remaining:" "${RESET}" "$(format_number "$remaining_context")" "$(format_number "$current_context")" "$context_percentage"
-        # Pacman meter (when in pacman mode)
-        if [ "$ICON_MODE" = "pacman" ] && [ "$current_context" -gt 0 ]; then
-            local pm_tier
-            pm_tier=$(get_activity_tier "$last_ts" "$current_context" "$DELTAS")
-            local meter_width=$((GRAPH_WIDTH - 10))
-            [ "$meter_width" -gt 40 ] && meter_width=40
-            local meter
-            meter=$(render_pacman_meter "$usage_percentage" "$pm_tier" "$meter_width")
-            printf '  %b%s%b\n' "${status_color}" "$meter" "${RESET}"
-        fi
         # Status indicator
         printf '  %b%b>>> %s <<<%b %b(%s)%b\n' "${status_color}" "${BOLD}" "$status_text" "${RESET}" "${DIM}" "$status_hint" "${RESET}"
         echo ""
@@ -1043,11 +954,6 @@ load_config() {
                     TOKEN_DETAIL_ENABLED=false
                 fi
                 ;;
-            icon_mode)
-                case "$value" in
-                    standard|pacman|off) ICON_MODE="$value" ;;
-                esac
-                ;;
             reduced_motion)
                 if [ "$value" = "true" ]; then
                     REDUCED_MOTION=true
@@ -1080,28 +986,24 @@ render_once() {
         echo -e "${BOLD}${MAGENTA}Context Stats${RESET} ${DIM}(Session: $session_name)${RESET}"
     fi
 
-    # Activity indicator (icon + waiting text)
-    if [ "$ICON_MODE" != "off" ]; then
-        local last_ts
-        last_ts=$(get_element "$TIMESTAMPS" "$DATA_COUNT")
-        local last_context
-        last_context=$(get_element "$CONTEXT_SIZES" "$DATA_COUNT")
-        [ -z "$last_context" ] && last_context=0
+    # Activity indicator (waiting text + label)
+    local last_ts
+    last_ts=$(get_element "$TIMESTAMPS" "$DATA_COUNT")
+    local last_context
+    last_context=$(get_element "$CONTEXT_SIZES" "$DATA_COUNT")
+    [ -z "$last_context" ] && last_context=0
 
-        local tier
-        tier=$(get_activity_tier "$last_ts" "$last_context" "$DELTAS")
-        local icon
-        icon=$(get_activity_icon "$tier" "$ICON_MODE")
-        local label
-        label=$(get_tier_label "$tier")
+    local tier
+    tier=$(get_activity_tier "$last_ts" "$last_context" "$DELTAS")
+    local label
+    label=$(get_tier_label "$tier")
 
-        if is_session_active "$last_ts"; then
-            local wait_text
-            wait_text=$(get_waiting_text "$CYCLE_COUNTER")
-            echo -e "  ${icon} ${DIM}${wait_text} [${label}]${RESET}"
-        else
-            echo -e "  ${icon} ${DIM}${label}${RESET}"
-        fi
+    if is_session_active "$last_ts"; then
+        local wait_text
+        wait_text=$(get_waiting_text "$CYCLE_COUNTER")
+        echo -e "  ${DIM}${wait_text} [${label}]${RESET}"
+    else
+        echo -e "  ${DIM}${label}${RESET}"
     fi
 
     # Render graphs (use CURRENT_USED_TOKENS for actual context window usage)

--- a/scripts/statusline-full.sh
+++ b/scripts/statusline-full.sh
@@ -63,7 +63,6 @@ autocompact_enabled=true
 token_detail_enabled=true
 show_delta_enabled=true
 show_session_enabled=true
-icon_mode="standard"
 autocompact=""    # Will be set by sourced config
 token_detail=""   # Will be set by sourced config
 show_delta=""     # Will be set by sourced config
@@ -71,8 +70,6 @@ show_session=""   # Will be set by sourced config
 ac_info=""
 delta_info=""
 session_info=""
-icon_info=""
-last_delta=0
 
 # Create config file with defaults if it doesn't exist
 if [[ ! -f ~/.claude/statusline.conf ]]; then
@@ -108,10 +105,6 @@ if [[ -f ~/.claude/statusline.conf ]]; then
     if [[ "$show_session" == "false" ]]; then
         show_session_enabled=false
     fi
-    case "$icon_mode" in
-        standard|pacman|off) ;; # already set by sourced config
-        *) icon_mode="standard" ;; # reset invalid values
-    esac
 fi
 
 # Width-fitting helpers
@@ -165,38 +158,6 @@ fit_to_width() {
     done
 
     echo -e "$result"
-}
-
-# Activity icon helper
-get_sl_activity_icon() {
-    local delta_val=$1
-    local ctx_size=$2
-    local mode=$3
-
-    if [[ "$mode" == "off" ]]; then echo ""; return; fi
-
-    if [[ "$delta_val" -le 0 ]]; then
-        [[ "$mode" == "pacman" ]] && echo "·" || echo "○"
-        return
-    fi
-
-    if [[ "$ctx_size" -le 0 ]]; then
-        [[ "$mode" == "pacman" ]] && echo "ᗧ···" || echo "◐"
-        return
-    fi
-
-    # delta as pct x100 for integer math
-    local pct_x100=$((delta_val * 10000 / ctx_size))
-
-    if [[ "$pct_x100" -gt 1500 ]]; then
-        [[ "$mode" == "pacman" ]] && echo "👻ᗧ●●●" || echo "💥"
-    elif [[ "$pct_x100" -gt 500 ]]; then
-        [[ "$mode" == "pacman" ]] && echo "ᗧ●●●" || echo "⚡"
-    elif [[ "$pct_x100" -gt 200 ]]; then
-        [[ "$mode" == "pacman" ]] && echo "ᗧ○·●" || echo "◉"
-    else
-        [[ "$mode" == "pacman" ]] && echo "ᗧ···" || echo "◐"
-    fi
 }
 
 # Calculate context window - show remaining free space
@@ -303,7 +264,7 @@ if [[ "$total_size" -gt 0 && "$current_usage" != "null" ]]; then
         fi
         # Calculate delta
         delta=$((used_tokens - prev_tokens))
-        last_delta=$delta
+        # delta calculated for display
         # Only show positive delta (and skip first run when no previous state)
         if [[ "$has_prev" == "true" && "$delta" -gt 0 ]]; then
             if [[ "$token_detail_enabled" == "true" ]]; then
@@ -329,17 +290,7 @@ if [[ "$show_session_enabled" == "true" && -n "$session_id" ]]; then
     session_info=" ${DIM}${session_id}${RESET}"
 fi
 
-# Activity icon
-if [[ "$icon_mode" != "off" && "$total_size" -gt 0 ]]; then
-    icon_delta=$last_delta
-    [[ "$icon_delta" -lt 0 ]] && icon_delta=0
-    sl_icon=$(get_sl_activity_icon "$icon_delta" "$total_size" "$icon_mode")
-    if [[ -n "$sl_icon" ]]; then
-        icon_info=" ${sl_icon}"
-    fi
-fi
-
-# Output: [Model] directory | branch [changes] | XXk free (XX%) icon [+delta] [AC] [S:session_id]
+# Output: [Model] directory | branch [changes] | XXk free (XX%) [+delta] [AC] [S:session_id]
 base="${DIM}[${model}]${RESET} ${BLUE}${dir_name}${RESET}"
 max_width=$(get_terminal_width)
-fit_to_width "$max_width" "$base" "$git_info" "$context_info" "$icon_info" "$delta_info" "$ac_info" "$session_info"
+fit_to_width "$max_width" "$base" "$git_info" "$context_info" "$delta_info" "$ac_info" "$session_info"

--- a/scripts/statusline.js
+++ b/scripts/statusline.js
@@ -126,7 +126,6 @@ function readConfig() {
         showDelta: true,
         showSession: true,
         showIoTokens: true,
-        iconMode: 'standard',
         reducedMotion: false,
     };
     const configPath = path.join(os.homedir(), '.claude', 'statusline.conf');
@@ -178,10 +177,6 @@ show_session=true
                 config.showSession = valueTrimmed !== 'false';
             } else if (keyTrimmed === 'show_io_tokens') {
                 config.showIoTokens = valueTrimmed !== 'false';
-            } else if (keyTrimmed === 'icon_mode') {
-                if (['standard', 'pacman', 'off'].includes(valueTrimmed)) {
-                    config.iconMode = valueTrimmed;
-                }
             } else if (keyTrimmed === 'reduced_motion') {
                 config.reducedMotion = valueTrimmed !== 'false';
             }
@@ -190,36 +185,6 @@ show_session=true
         // Ignore errors
     }
     return config;
-}
-
-function getActivityIcon(delta, totalSize, iconMode) {
-    if (iconMode === 'off') {
-        return '';
-    }
-
-    const icons =
-        iconMode === 'pacman'
-            ? { idle: '·', low: 'ᗧ···', medium: 'ᗧ○·●', high: 'ᗧ●●●', spike: '👻ᗧ●●●' }
-            : { idle: '○', low: '◐', medium: '◉', high: '⚡', spike: '💥' };
-
-    if (delta <= 0) {
-        return icons.idle;
-    }
-    if (totalSize <= 0) {
-        return icons.low;
-    }
-
-    const pct = (delta / totalSize) * 100;
-    if (pct > 15) {
-        return icons.spike;
-    }
-    if (pct > 5) {
-        return icons.high;
-    }
-    if (pct > 2) {
-        return icons.medium;
-    }
-    return icons.low;
 }
 
 let input = '';
@@ -261,7 +226,6 @@ process.stdin.on('end', () => {
     let acInfo = '';
     let deltaInfo = '';
     let sessionInfo = '';
-    let lastDelta = 0;
     const totalSize = data.context_window?.context_window_size || 0;
     const currentUsage = data.context_window?.current_usage;
     const totalInputTokens = data.context_window?.total_input_tokens || 0;
@@ -379,7 +343,6 @@ process.stdin.on('end', () => {
             }
             // Calculate delta (difference in context window usage)
             const delta = usedTokens - prevTokens;
-            lastDelta = delta;
             // Only show positive delta (and skip first run when no previous state)
             if (hasPrev && delta > 0) {
                 const deltaDisplay = tokenDetail
@@ -425,18 +388,9 @@ process.stdin.on('end', () => {
         sessionInfo = ` ${DIM}${sessionId}${RESET}`;
     }
 
-    // Activity icon based on delta and context window
-    let iconInfo = '';
-    if (config.iconMode !== 'off' && totalSize > 0) {
-        const icon = getActivityIcon(Math.max(0, lastDelta), totalSize, config.iconMode);
-        if (icon) {
-            iconInfo = ` ${icon}`;
-        }
-    }
-
-    // Output: [Model] dir | branch [n] | icon free (%) [+delta] [AC] session
+    // Output: [Model] dir | branch [n] | free (%) [+delta] [AC] session
     const base = `${DIM}[${model}]${RESET} ${BLUE}${dirName}${RESET}`;
     const maxWidth = getTerminalWidth();
-    const parts = [base, gitInfo, contextInfo, iconInfo, deltaInfo, acInfo, sessionInfo];
+    const parts = [base, gitInfo, contextInfo, deltaInfo, acInfo, sessionInfo];
     console.log(fitToWidth(parts, maxWidth));
 });

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -115,31 +115,6 @@ def get_git_info(project_dir):
         return ""
 
 
-def get_activity_icon(delta: int, total_size: int, icon_mode: str) -> str:
-    """Get activity icon based on token delta."""
-    if icon_mode == "off":
-        return ""
-
-    pacman = icon_mode == "pacman"
-
-    if delta <= 0:
-        return "\u00b7" if pacman else "\u25cb"  # · or ○
-
-    if total_size <= 0:
-        return "\u15e7\u00b7\u00b7\u00b7" if pacman else "\u25d0"  # ᗧ··· or ◐
-
-    pct = (delta / total_size) * 100
-
-    if pct > 15:
-        return "\U0001f47b\u15e7\u25cf\u25cf\u25cf" if pacman else "\U0001f4a5"  # 👻ᗧ●●● or 💥
-    elif pct > 5:
-        return "\u15e7\u25cf\u25cf\u25cf" if pacman else "\u26a1"  # ᗧ●●● or ⚡
-    elif pct > 2:
-        return "\u15e7\u25cb\u00b7\u25cf" if pacman else "\u25c9"  # ᗧ○·● or ◉
-    else:
-        return "\u15e7\u00b7\u00b7\u00b7" if pacman else "\u25d0"  # ᗧ··· or ◐
-
-
 def read_config():
     """Read settings from config file"""
     config = {
@@ -148,7 +123,6 @@ def read_config():
         "show_delta": True,
         "show_session": True,
         "show_io_tokens": True,
-        "icon_mode": "standard",
     }
     config_path = os.path.expanduser("~/.claude/statusline.conf")
 
@@ -195,9 +169,6 @@ show_session=true
                     config["show_session"] = value != "false"
                 elif key == "show_io_tokens":
                     config["show_io_tokens"] = value != "false"
-                elif key == "icon_mode":
-                    if value in ("standard", "pacman", "off"):
-                        config["icon_mode"] = value
     except Exception:
         pass
     return config
@@ -235,8 +206,6 @@ def main():
     ac_info = ""
     delta_info = ""
     session_info = ""
-    icon_info = ""
-    last_delta = 0
     total_size = data.get("context_window", {}).get("context_window_size", 0)
     current_usage = data.get("context_window", {}).get("current_usage")
     total_input_tokens = data.get("context_window", {}).get("total_input_tokens", 0)
@@ -333,7 +302,6 @@ def main():
                 prev_tokens = 0
             # Calculate delta
             delta = used_tokens - prev_tokens
-            last_delta = delta
             # Only show positive delta (and skip first run when no previous state)
             if has_prev and delta > 0:
                 if token_detail:
@@ -374,17 +342,10 @@ def main():
     if show_session and session_id:
         session_info = f" {DIM}{session_id}{RESET}"
 
-    # Activity icon
-    icon_mode = config.get("icon_mode", "standard")
-    if icon_mode != "off" and total_size > 0:
-        icon = get_activity_icon(max(0, last_delta), total_size, icon_mode)
-        if icon:
-            icon_info = f" {icon}"
-
-    # Output: [Model] directory | branch [changes] | XXk free (XX%) icon [+delta] [AC] [S:session_id]
+    # Output: [Model] directory | branch [changes] | XXk free (XX%) [+delta] [AC] [S:session_id]
     base = f"{DIM}[{model}]{RESET} {BLUE}{dir_name}{RESET}"
     max_width = get_terminal_width()
-    parts = [base, git_info, context_info, icon_info, delta_info, ac_info, session_info]
+    parts = [base, git_info, context_info, delta_info, ac_info, session_info]
     print(fit_to_width(parts, max_width))
 
 

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -27,7 +27,7 @@ from claude_statusline.core.config import Config
 from claude_statusline.core.state import StateFile
 from claude_statusline.graphs.renderer import GraphDimensions, GraphRenderer
 from claude_statusline.graphs.statistics import calculate_deltas
-from claude_statusline.ui.icons import get_activity_icon, get_activity_tier, get_tier_label
+from claude_statusline.ui.icons import get_activity_tier, get_tier_label
 from claude_statusline.ui.waiting import get_waiting_text, is_active
 
 # Cursor control sequences
@@ -158,7 +158,7 @@ def render_once(
         renderer: GraphRenderer instance
         colors: ColorManager instance
         watch_mode: Whether running in watch mode
-        config: Config instance for icon/motion settings
+        config: Config instance for motion settings
         cycle_index: Watch mode refresh counter for rotating text
 
     Returns:
@@ -223,20 +223,17 @@ def render_once(
             f"{colors.dim}(Session: {session_name}){colors.reset}"
         )
 
-    # Activity indicator (icon + waiting text)
-    icon_mode = config.icon_mode if config else "standard"
+    # Activity indicator (waiting text + label)
     reduced_motion = config.reduced_motion if config else False
-    if icon_mode != "off":
-        tier = get_activity_tier(entries, last_entry.context_window_size)
-        icon = get_activity_icon(tier, icon_mode)
-        label = get_tier_label(tier)
-        active = is_active(entries)
+    tier = get_activity_tier(entries, last_entry.context_window_size)
+    label = get_tier_label(tier)
+    active = is_active(entries)
 
-        if active:
-            text = get_waiting_text(cycle_index, reduced_motion)
-            emit(f"  {icon} {colors.dim}{text} [{label}]{colors.reset}")
-        else:
-            emit(f"  {icon} {colors.dim}{label}{colors.reset}")
+    if active:
+        text = get_waiting_text(cycle_index, reduced_motion)
+        emit(f"  {colors.dim}{text} [{label}]{colors.reset}")
+    else:
+        emit(f"  {colors.dim}{label}{colors.reset}")
 
     # In watch mode, enable renderer buffering
     if watch_mode:
@@ -262,7 +259,7 @@ def render_once(
         )
 
     # Summary and footer
-    renderer.render_summary(entries, deltas, icon_mode=icon_mode)
+    renderer.render_summary(entries, deltas)
     renderer.render_footer(__version__)
 
     if watch_mode:
@@ -290,7 +287,7 @@ def run_watch_mode(
         interval: Refresh interval in seconds
         renderer: GraphRenderer instance
         colors: ColorManager instance
-        config: Config instance for icon/motion settings
+        config: Config instance for motion settings
     """
 
     # Signal handler for clean exit

--- a/src/claude_statusline/core/config.py
+++ b/src/claude_statusline/core/config.py
@@ -16,7 +16,6 @@ class Config:
     show_delta: bool = True
     show_session: bool = True
     show_io_tokens: bool = True
-    icon_mode: str = "standard"
     reduced_motion: bool = False
 
     _config_path: Path = field(default_factory=lambda: Path.home() / ".claude" / "statusline.conf")
@@ -60,10 +59,7 @@ show_delta=true
 # Show session_id in status line
 show_session=true
 
-# Activity icon mode: standard, pacman, or off
-icon_mode=standard
-
-# Disable rotating text and icon animations
+# Disable rotating text animations
 reduced_motion=false
 """
             )
@@ -92,9 +88,6 @@ reduced_motion=false
                     self.show_session = value != "false"
                 elif key == "show_io_tokens":
                     self.show_io_tokens = value != "false"
-                elif key == "icon_mode":
-                    if value in ("standard", "pacman", "off"):
-                        self.icon_mode = value
                 elif key == "reduced_motion":
                     self.reduced_motion = value != "false"
         except OSError:
@@ -108,6 +101,5 @@ reduced_motion=false
             "show_delta": self.show_delta,
             "show_session": self.show_session,
             "show_io_tokens": self.show_io_tokens,
-            "icon_mode": self.icon_mode,
             "reduced_motion": self.reduced_motion,
         }

--- a/src/claude_statusline/graphs/renderer.py
+++ b/src/claude_statusline/graphs/renderer.py
@@ -9,7 +9,6 @@ from claude_statusline.core.colors import ColorManager
 from claude_statusline.formatters.time import format_duration, format_timestamp
 from claude_statusline.formatters.tokens import format_tokens
 from claude_statusline.graphs.statistics import calculate_deltas, calculate_stats
-from claude_statusline.ui.icons import ActivityTier, get_activity_tier, render_pacman_meter
 
 
 @dataclass
@@ -260,14 +259,12 @@ class GraphRenderer:
         self,
         entries: list,  # list[StateEntry]
         deltas: list[int],
-        icon_mode: str = "standard",
     ) -> None:
         """Render summary statistics.
 
         Args:
             entries: List of StateEntry objects
             deltas: List of token deltas
-            icon_mode: Icon mode - "standard", "pacman", or "off"
         """
         if not entries:
             return
@@ -312,13 +309,6 @@ class GraphRenderer:
                 f"  {status_color}{'Context Remaining:':<20}{self.colors.reset} "
                 f"{format_tokens(remaining_context, self.token_detail)}/{format_tokens(last.context_window_size, self.token_detail)} ({remaining_percentage}%)"
             )
-
-        # Pacman meter (when in pacman mode)
-        if icon_mode == "pacman" and last.context_window_size > 0:
-            tier = get_activity_tier(entries, last.context_window_size)
-            meter_width = min(40, self.dimensions.graph_width - 10)
-            meter = render_pacman_meter(usage_percentage, tier, meter_width)
-            self._emit(f"  {status_color}{meter}{self.colors.reset}")
 
         # Status indicator - highlighted
         if last.context_window_size > 0:

--- a/src/claude_statusline/ui/icons.py
+++ b/src/claude_statusline/ui/icons.py
@@ -1,4 +1,4 @@
-"""Activity icons and Pacman meter for token usage visualization."""
+"""Activity tier detection for token usage visualization."""
 
 from __future__ import annotations
 
@@ -17,24 +17,6 @@ class ActivityTier(Enum):
     HIGH = "high"
     SPIKE = "spike"
 
-
-# Standard mode icons (meaningful without color)
-STANDARD_ICONS: dict[ActivityTier, str] = {
-    ActivityTier.IDLE: "\u25cb",     # ○ empty circle
-    ActivityTier.LOW: "\u25d0",      # ◐ half circle
-    ActivityTier.MEDIUM: "\u25c9",   # ◉ bullseye
-    ActivityTier.HIGH: "\u26a1",     # ⚡ lightning
-    ActivityTier.SPIKE: "\U0001f4a5",  # 💥 burst
-}
-
-# Pacman mode icons
-PACMAN_ICONS: dict[ActivityTier, str] = {
-    ActivityTier.IDLE: "\u00b7",            # · dot
-    ActivityTier.LOW: "\u15e7\u00b7\u00b7\u00b7",      # ᗧ···
-    ActivityTier.MEDIUM: "\u15e7\u25cb\u00b7\u25cf",    # ᗧ○·●
-    ActivityTier.HIGH: "\u15e7\u25cf\u25cf\u25cf",      # ᗧ●●●
-    ActivityTier.SPIKE: "\U0001f47b\u15e7\u25cf\u25cf\u25cf",  # 👻ᗧ●●●
-}
 
 # Tier labels for accessibility (understandable without color)
 TIER_LABELS: dict[ActivityTier, str] = {
@@ -99,24 +81,6 @@ def get_activity_tier(
         return ActivityTier.IDLE
 
 
-def get_activity_icon(tier: ActivityTier, mode: str = "standard") -> str:
-    """Get the icon for an activity tier.
-
-    Args:
-        tier: The activity tier
-        mode: Icon mode - "standard", "pacman", or "off"
-
-    Returns:
-        Icon string, or empty string if mode is "off"
-    """
-    if mode == "off":
-        return ""
-    elif mode == "pacman":
-        return PACMAN_ICONS.get(tier, "")
-    else:
-        return STANDARD_ICONS.get(tier, "")
-
-
 def get_tier_label(tier: ActivityTier) -> str:
     """Get an accessible text label for a tier.
 
@@ -127,49 +91,3 @@ def get_tier_label(tier: ActivityTier) -> str:
         Human-readable label string
     """
     return TIER_LABELS.get(tier, "")
-
-
-def render_pacman_meter(
-    usage_pct: int,
-    tier: ActivityTier,
-    width: int = 30,
-) -> str:
-    """Render a Pacman-style context usage meter.
-
-    The meter shows Pacman eating through a bar representing context usage.
-    Pacman's position corresponds to the usage percentage.
-
-    Args:
-        usage_pct: Context usage percentage (0-100)
-        tier: Current activity tier (affects Pacman appearance)
-        width: Total width of the meter bar in characters
-
-    Returns:
-        Formatted meter string (no color codes - caller adds color)
-    """
-    usage_pct = max(0, min(100, usage_pct))
-    bar_width = max(10, width)
-
-    # Pacman position along the bar
-    pacman_pos = int((usage_pct / 100) * (bar_width - 1))
-    pacman_pos = max(0, min(bar_width - 1, pacman_pos))
-
-    # Choose Pacman character
-    if usage_pct > 80:
-        pacman = "\u15e4"  # ᗤ fat pacman
-    else:
-        pacman = "\u15e7"  # ᗧ normal pacman
-
-    # Ghost at the end during spikes
-    ghost = "\U0001f47b" if tier == ActivityTier.SPIKE else " "
-
-    # Build the bar
-    # Left of pacman: empty (already eaten) = ░
-    # Right of pacman: filled (yet to eat) = █
-    eaten = "\u2591" * pacman_pos          # ░ light shade
-    remaining = "\u2588" * (bar_width - pacman_pos - 1)  # █ full block
-
-    meter = f"{eaten}{pacman}{remaining}{ghost}"
-    label = f" {usage_pct}% used"
-
-    return f"{meter}{label}"

--- a/tests/python/test_icons.py
+++ b/tests/python/test_icons.py
@@ -1,4 +1,4 @@
-"""Tests for activity icons and Pacman meter."""
+"""Tests for activity tier detection."""
 
 import time
 
@@ -6,10 +6,8 @@ from claude_statusline.core.state import StateEntry
 from claude_statusline.graphs.statistics import detect_spike
 from claude_statusline.ui.icons import (
     ActivityTier,
-    get_activity_icon,
     get_activity_tier,
     get_tier_label,
-    render_pacman_meter,
 )
 
 
@@ -139,33 +137,6 @@ class TestActivityTier:
         assert get_activity_tier(entries, 200_000) == ActivityTier.IDLE
 
 
-class TestGetActivityIcon:
-    """Tests for icon selection."""
-
-    def test_standard_mode_returns_icons(self):
-        for tier in ActivityTier:
-            icon = get_activity_icon(tier, "standard")
-            assert len(icon) > 0
-
-    def test_pacman_mode_returns_icons(self):
-        for tier in ActivityTier:
-            icon = get_activity_icon(tier, "pacman")
-            assert len(icon) > 0
-
-    def test_off_mode_returns_empty(self):
-        for tier in ActivityTier:
-            icon = get_activity_icon(tier, "off")
-            assert icon == ""
-
-    def test_standard_icons_are_different_per_tier(self):
-        icons = {get_activity_icon(tier, "standard") for tier in ActivityTier}
-        assert len(icons) == len(ActivityTier)
-
-    def test_pacman_icons_are_different_per_tier(self):
-        icons = {get_activity_icon(tier, "pacman") for tier in ActivityTier}
-        assert len(icons) == len(ActivityTier)
-
-
 class TestGetTierLabel:
     """Tests for tier labels."""
 
@@ -179,49 +150,3 @@ class TestGetTierLabel:
 
     def test_spike_label(self):
         assert get_tier_label(ActivityTier.SPIKE) == "Spike!"
-
-
-class TestPacmanMeter:
-    """Tests for Pacman meter rendering."""
-
-    def test_zero_usage(self):
-        meter = render_pacman_meter(0, ActivityTier.LOW, width=20)
-        assert "0% used" in meter
-
-    def test_full_usage(self):
-        meter = render_pacman_meter(100, ActivityTier.HIGH, width=20)
-        assert "100% used" in meter
-
-    def test_clamped_over_100(self):
-        meter = render_pacman_meter(150, ActivityTier.HIGH, width=20)
-        assert "100% used" in meter
-
-    def test_clamped_under_0(self):
-        meter = render_pacman_meter(-10, ActivityTier.IDLE, width=20)
-        assert "0% used" in meter
-
-    def test_fat_pacman_over_80(self):
-        """Usage >80% should use fat pacman character."""
-        meter = render_pacman_meter(85, ActivityTier.HIGH, width=20)
-        assert "\u15e4" in meter  # ᗤ fat pacman
-
-    def test_normal_pacman_under_80(self):
-        """Usage <=80% should use normal pacman character."""
-        meter = render_pacman_meter(50, ActivityTier.MEDIUM, width=20)
-        assert "\u15e7" in meter  # ᗧ normal pacman
-
-    def test_ghost_on_spike(self):
-        """Spike tier should include a ghost."""
-        meter = render_pacman_meter(60, ActivityTier.SPIKE, width=20)
-        assert "\U0001f47b" in meter  # 👻 ghost
-
-    def test_no_ghost_without_spike(self):
-        """Non-spike tiers should not include a ghost."""
-        meter = render_pacman_meter(60, ActivityTier.MEDIUM, width=20)
-        assert "\U0001f47b" not in meter
-
-    def test_minimum_width(self):
-        """Meter should enforce minimum width."""
-        meter = render_pacman_meter(50, ActivityTier.LOW, width=5)
-        # Should still render (min width enforced internally)
-        assert "50% used" in meter


### PR DESCRIPTION
## Summary
- Remove `icon_mode` config option (`standard`/`pacman`/`off`) from all statusline implementations (Python CLI, standalone Python, Node.js, Bash)
- Remove activity icons (○ ◐ ◉ ⚡ 💥), pacman icons (ᗧ··· ᗧ●●● 👻ᗧ●●●), and pacman meter bar visualization
- Preserve `ActivityTier` enum and text labels ("Idle", "Low activity", etc.) used by context-stats
- Net removal of ~413 lines across 10 files

## Test plan
- [x] All 70 Python tests pass
- [ ] Verify statusline renders correctly without icons
- [ ] Verify context-stats summary no longer shows pacman meter
- [ ] Verify existing `icon_mode` in user config files is silently ignored