### PR TITLE
chore: add open-source standard files and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Install cc-context-stats via '...'
+2. Run '...'
+3. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+What actually happened instead.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- OS: [e.g., macOS 14.0, Ubuntu 22.04, Windows 11]
+- Shell: [e.g., zsh, bash, PowerShell]
+- cc-context-stats version: [e.g., 1.5.1]
+- Installation method: [npm, pip, shell script]
+- Node.js version: [if applicable]
+- Python version: [if applicable]
+- Claude Code version: [if applicable]
+
+## Additional Context
+
+Add any other context about the problem here.
+
+## State File Content (if relevant)
+
+```
+# Paste output of: cat ~/.claude/statusline/statusline.*.state
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+A clear and concise description of what the problem is.
+Ex. I'm always frustrated when [...]
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Use Cases
+
+Describe specific use cases where this feature would be beneficial:
+
+1. Use case 1
+2. Use case 2
+
+## Additional Context
+
+Add any other context, mockups, or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Description
+
+Brief description of the changes in this PR.
+
+## Related Issue
+
+Fixes #(issue number)
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] All three implementations (bash, Python, Node.js) produce consistent output (if applicable)
+
+## Screenshots (if applicable)
+
+Add screenshots to help explain your changes.
+
+## Additional Notes
+
+Any additional information that reviewers should know.

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ publish.sh
 npm-publish.sh
 PUBLISHING_GUIDE.md
 show_raw_claude_code_api.js
+
+# Ruff
+.ruff_cache/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+luongnv89@gmail.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nguyen Luong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -177,8 +177,17 @@ Context Stats hooks into Claude Code's state files to track token usage across y
 - [Context Stats Guide](docs/context-stats.md) - Detailed usage guide
 - [Configuration Options](docs/configuration.md) - All settings explained
 - [Installation Guide](docs/installation.md) - Platform-specific setup
+- [Architecture](docs/ARCHITECTURE.md) - System design and components
+- [Development](docs/DEVELOPMENT.md) - Dev setup and debugging
+- [Deployment](docs/DEPLOYMENT.md) - Publishing and release process
 - [Troubleshooting](docs/troubleshooting.md) - Common issues
 - [Changelog](CHANGELOG.md) - Version history
+
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details on the development setup, branching strategy, and PR process.
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Migration from cc-statusline
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.5.x   | :white_check_mark: |
+| < 1.5   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously. If you discover a security issue, please report it responsibly.
+
+### How to Report
+
+1. **Do NOT** open a public GitHub issue for security vulnerabilities
+2. Email your findings to luongnv89@gmail.com
+3. Include detailed steps to reproduce the vulnerability
+4. Allow up to 48 hours for an initial response
+
+### What to Include
+
+- Type of vulnerability
+- Full paths of affected source files
+- Location of the affected source code (tag/branch/commit or direct URL)
+- Step-by-step instructions to reproduce
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue
+
+### What to Expect
+
+- Acknowledgment of your report within 48 hours
+- Regular updates on our progress
+- Credit in the security advisory (if desired)
+- Notification when the issue is fixed
+
+## Security Best Practices
+
+When contributing to this project:
+
+- Never commit secrets, API keys, or credentials
+- Use environment variables for sensitive configuration
+- Follow secure coding practices
+- Report any security concerns immediately

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# Architecture
+
+## Overview
+
+cc-context-stats provides real-time context monitoring for Claude Code sessions. It consists of two main components:
+
+1. **Status Line** - A compact one-line display integrated into Claude Code's UI
+2. **Context Stats CLI** - A live terminal dashboard with ASCII graphs
+
+## System Architecture
+
+```
+┌─────────────┐     JSON stdin      ┌──────────────────┐
+│ Claude Code  │ ──────────────────> │ Statusline Script │
+│   (host)     │ <────────────────── │  (sh/py/js)       │
+└─────────────┘     stdout text     └──────┬───────────┘
+                                           │ writes
+                                           ▼
+                                    ┌──────────────────┐
+                                    │  State Files      │
+                                    │  ~/.claude/       │
+                                    │  statusline/      │
+                                    └──────┬───────────┘
+                                           │ reads
+                                           ▼
+                                    ┌──────────────────┐
+                                    │ Context Stats CLI │
+                                    │  (Python)         │
+                                    └──────────────────┘
+```
+
+## Component Details
+
+### Status Line Scripts
+
+Three implementation languages with identical output:
+
+| Script                | Language   | Dependencies |
+| --------------------- | ---------- | ------------ |
+| `statusline-full.sh`  | Bash       | `jq`         |
+| `statusline-git.sh`   | Bash       | `jq`         |
+| `statusline-minimal.sh` | Bash    | `jq`         |
+| `statusline.py`       | Python 3   | None         |
+| `statusline.js`       | Node.js 18+| None         |
+
+**Data flow:**
+1. Claude Code pipes JSON state via stdin on each refresh
+2. Script parses model info, context tokens, session data
+3. Script reads `~/.claude/statusline.conf` for user preferences
+4. Script checks git status for branch/changes info
+5. Script writes state to `~/.claude/statusline/<session_id>.state`
+6. Script outputs formatted ANSI text to stdout
+
+### Python Package (`src/claude_statusline/`)
+
+The pip-installable package provides both the statusline and context-stats CLI:
+
+```
+src/claude_statusline/
+├── __init__.py
+├── __main__.py
+├── cli/
+│   ├── statusline.py      # claude-statusline entry point
+│   └── context_stats.py   # context-stats entry point
+├── core/
+│   ├── colors.py          # ANSI color management
+│   ├── config.py          # Configuration loading
+│   ├── git.py             # Git status detection
+│   └── state.py           # State file reading/writing
+├── formatters/
+│   ├── layout.py          # Output width/layout management
+│   ├── time.py            # Duration formatting
+│   └── tokens.py          # Token count formatting
+├── graphs/
+│   ├── renderer.py        # ASCII graph rendering
+│   └── statistics.py      # Data statistics
+└── ui/
+    ├── icons.py           # Unicode icons
+    └── waiting.py         # Waiting animation
+```
+
+### State Files
+
+State files persist token history between statusline refreshes:
+
+```
+~/.claude/statusline/statusline.<session_id>.state
+```
+
+Each line is a JSON record with timestamp, token counts, and context metrics. The context-stats CLI reads these files to render graphs.
+
+## Data Privacy
+
+All data stays local:
+- State files are written to `~/.claude/statusline/`
+- No network requests are made
+- No telemetry or analytics
+
+## Configuration
+
+User preferences are stored in `~/.claude/statusline.conf` as simple `key=value` pairs. See [Configuration](configuration.md) for details.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,60 @@
+# Deployment
+
+## Distribution Channels
+
+cc-context-stats is distributed through three channels:
+
+| Channel      | Package Name      | Command                              |
+| ------------ | ----------------- | ------------------------------------ |
+| Shell script | N/A               | `curl -fsSL .../install.sh \| bash`  |
+| PyPI         | `cc-context-stats`| `pip install cc-context-stats`       |
+| npm          | `cc-context-stats`| `npm install -g cc-context-stats`    |
+
+## Publishing to PyPI
+
+```bash
+# Ensure clean build
+rm -rf dist/ build/
+
+# Build
+python -m build
+
+# Check package
+twine check dist/*
+
+# Upload to PyPI
+twine upload dist/*
+```
+
+## Publishing to npm
+
+```bash
+# Verify package.json
+npm pack --dry-run
+
+# Publish
+npm publish
+```
+
+## Release Workflow
+
+The project uses GitHub Actions for automated releases (`.github/workflows/release.yml`):
+
+1. Create and push a version tag: `git tag v1.x.x && git push --tags`
+2. The release workflow automatically:
+   - Runs the full test suite
+   - Builds Python and npm packages
+   - Creates a GitHub Release with release notes
+
+## Version Management
+
+Versions must be updated in sync across:
+
+- `pyproject.toml` - `[project] version`
+- `package.json` - `version`
+- `CHANGELOG.md` - New version entry
+- `RELEASE_NOTES.md` - Current release notes
+
+## Install Script
+
+The `install.sh` script is fetched directly from the `main` branch on GitHub. Changes to the installer take effect immediately for new users running the curl one-liner.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,125 @@
+# Development Guide
+
+## Prerequisites
+
+- **Git** - Version control
+- **jq** - JSON processor (for bash scripts)
+- **Python 3.9+** - For Python package and testing
+- **Node.js 18+** - For Node.js script and testing
+- **Bats** - Bash Automated Testing System (optional, for bash tests)
+
+## Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/luongnv89/cc-context-stats.git
+cd cc-context-stats
+
+# Python setup
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements-dev.txt
+pip install -e ".[dev]"
+
+# Node.js setup
+npm install
+
+# Install pre-commit hooks
+pre-commit install
+```
+
+## Project Layout
+
+```
+cc-context-stats/
+├── src/claude_statusline/    # Python package source
+├── scripts/                  # Standalone scripts (sh/py/js)
+├── tests/
+│   ├── bash/                 # Bats tests
+│   ├── python/               # Pytest tests
+│   └── node/                 # Jest tests
+├── config/                   # Configuration examples
+├── docs/                     # Documentation
+├── .github/workflows/        # CI/CD
+├── pyproject.toml            # Python build config
+└── package.json              # Node.js config
+```
+
+## Running Tests
+
+```bash
+# All tests
+npm test && pytest && bats tests/bash/*.bats
+
+# Individual suites
+pytest tests/python/ -v                          # Python
+pytest tests/python/ -v --cov=scripts --cov-report=html  # Python + coverage
+npm test                                          # Node.js (Jest)
+npm run test:coverage                             # Node.js + coverage
+bats tests/bash/*.bats                           # Bash
+```
+
+## Linting & Formatting
+
+```bash
+# Run all checks via pre-commit
+pre-commit run --all-files
+
+# Individual tools
+ruff check src/ scripts/statusline.py            # Python lint
+ruff format src/ scripts/statusline.py           # Python format
+npx eslint scripts/statusline.js                 # JavaScript lint
+npx prettier --write scripts/statusline.js       # JavaScript format
+shellcheck scripts/*.sh install.sh               # Bash lint
+```
+
+## Manual Testing
+
+```bash
+# Test statusline scripts with mock input
+echo '{"model":{"display_name":"Test"},"cwd":"/test","session_id":"abc123","context":{"tokens_remaining":64000,"context_window":200000}}' | python3 scripts/statusline.py
+
+echo '{"model":{"display_name":"Test"}}' | node scripts/statusline.js
+
+echo '{"model":{"display_name":"Test"}}' | bash scripts/statusline-full.sh
+```
+
+## Building
+
+```bash
+# Python package
+python -m build
+
+# Verify package
+twine check dist/*
+```
+
+## Cross-Script Consistency
+
+All three implementations (bash, Python, Node.js) must produce identical output for the same input. When modifying status line behavior:
+
+1. Update all three script variants
+2. Run integration tests to verify parity
+3. Test on multiple platforms if possible
+
+## Debugging
+
+### State files
+
+```bash
+# View current state files
+ls -la ~/.claude/statusline/statusline.*.state
+
+# Inspect state content
+cat ~/.claude/statusline/statusline.<session_id>.state
+```
+
+### Verbose testing
+
+```bash
+# Python with verbose output
+pytest tests/python/ -v -s
+
+# Node.js with verbose output
+npx jest --verbose
+```


### PR DESCRIPTION
## Summary
- Add LICENSE (MIT), CODE_OF_CONDUCT.md, SECURITY.md for OSS compliance
- Add GitHub issue templates (bug report, feature request) and PR template
- Add docs for architecture, development, and deployment
- Update README with contributing section and links to new docs
- Add `.ruff_cache/` to .gitignore

## Test plan
- [x] Verify LICENSE file has correct copyright holder and year
- [x] Verify CODE_OF_CONDUCT.md and SECURITY.md have correct contact email
- [x] Verify GitHub templates render correctly on GitHub
- [x] Verify README links to new docs are valid