### PR TITLE
Reorder statusline: prioritize context info over model name

### DIFF
--- a/scripts/statusline-full.sh
+++ b/scripts/statusline-full.sh
@@ -503,7 +503,9 @@ if [[ "$show_session_enabled" == "true" && -n "$session_id" ]]; then
     session_info=" | ${C_SEPARATOR}${session_id}${RESET}"
 fi
 
-# Output: [Model] directory | branch [changes] | XXk free (XX%) [+delta] [AC] [S:session_id]
-base="${C_SEPARATOR}${model}${RESET} | ${C_PROJECT_NAME}${dir_name}${RESET}"
+# Output: directory | branch [changes] | XXk free (XX%) | zone | MI | +delta | [Model] [S:session_id]
+# Model name is lowest priority — truncated first when terminal is narrow
+base="${C_PROJECT_NAME}${dir_name}${RESET}"
+model_info=" | ${C_SEPARATOR}${model}${RESET}"
 max_width=$(get_terminal_width)
-fit_to_width "$max_width" "$base" "$git_info" "$context_info" "$zone_info" "$mi_info" "$delta_info" "$session_info"
+fit_to_width "$max_width" "$base" "$git_info" "$context_info" "$zone_info" "$mi_info" "$delta_info" "$model_info" "$session_info"

--- a/scripts/statusline.js
+++ b/scripts/statusline.js
@@ -706,10 +706,12 @@ process.stdin.on('end', () => {
         sessionInfo = ` | ${cSeparator}${sessionId}${RESET}`;
     }
 
-    // Output: [Model] dir | branch [n] | free (%) [+delta] [AC] session
-    const base = `${cSeparator}${model}${RESET} | ${cProjectName}${dirName}${RESET}`;
+    // Output: dir | branch [n] | free (%) | zone | MI | +delta | [Model] session
+    // Model name is lowest priority — truncated first when terminal is narrow
+    const base = `${cProjectName}${dirName}${RESET}`;
+    const modelInfo = ` | ${cSeparator}${model}${RESET}`;
     const maxWidth = getTerminalWidth();
-    const parts = [base, gitInfo, contextInfo, zoneInfo, miInfo, deltaInfo, sessionInfo];
+    const parts = [base, gitInfo, contextInfo, zoneInfo, miInfo, deltaInfo, modelInfo, sessionInfo];
     console.log(fitToWidth(parts, maxWidth));
 });
 

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -631,10 +631,12 @@ def main():
     if show_session and session_id:
         session_info = f" | {c_separator}{session_id}{RESET}"
 
-    # Output: [Model] directory | branch [changes] | XXk free (XX%) [+delta] [AC] [S:session_id]
-    base = f"{c_separator}{model}{RESET} | {c_project_name}{dir_name}{RESET}"
+    # Output: directory | branch [changes] | XXk free (XX%) | zone | MI | +delta | [Model] [session_id]
+    # Model name is lowest priority — truncated first when terminal is narrow
+    base = f"{c_project_name}{dir_name}{RESET}"
+    model_info = f" | {c_separator}{model}{RESET}"
     max_width = get_terminal_width()
-    parts = [base, git_info, context_info, zone_info, mi_info, delta_info, session_info]
+    parts = [base, git_info, context_info, zone_info, mi_info, delta_info, model_info, session_info]
     print(fit_to_width(parts, max_width))
 
 

--- a/src/claude_statusline/cli/statusline.py
+++ b/src/claude_statusline/cli/statusline.py
@@ -195,10 +195,12 @@ def main() -> None:
     if config.show_session and session_id:
         session_info = f" | {colors.separator}{session_id}{colors.reset}"
 
-    # Output: [Model] directory | branch [changes] | XXk free (XX%) [+delta] [AC] [session_id]
-    base = f"{colors.separator}{model}{colors.reset} | {colors.project_name}{dir_name}{colors.reset}"
+    # Output: directory | branch [changes] | XXk free (XX%) | zone | MI | +delta | [Model] [session_id]
+    # Model name is lowest priority — truncated first when terminal is narrow
+    base = f"{colors.project_name}{dir_name}{colors.reset}"
+    model_info = f" | {colors.separator}{model}{colors.reset}"
     max_width = get_terminal_width()
-    parts = [base, git_info, context_info, zone_info, mi_info, delta_info, session_info]
+    parts = [base, git_info, context_info, zone_info, mi_info, delta_info, model_info, session_info]
     print(fit_to_width(parts, max_width))
 
 

--- a/tests/bash/test_statusline_full.bats
+++ b/tests/bash/test_statusline_full.bats
@@ -115,14 +115,15 @@ strip_ansi() {
     [ "$len" -le 80 ]
 }
 
-@test "narrow terminal still shows model and directory" {
-    input='{"model":{"display_name":"Claude"},"workspace":{"current_dir":"/tmp/proj","project_dir":"/tmp/proj"},"context_window":{"context_window_size":200000,"current_usage":{"input_tokens":10000,"cache_creation_input_tokens":500,"cache_read_input_tokens":200}}}'
+@test "narrow terminal prioritizes directory and context over model" {
+    input='{"model":{"display_name":"Claude 3.5 Sonnet"},"workspace":{"current_dir":"/tmp/myproject","project_dir":"/tmp/myproject"},"context_window":{"context_window_size":200000,"current_usage":{"input_tokens":10000,"cache_creation_input_tokens":500,"cache_read_input_tokens":200}}}'
     result=$(COLUMNS=40 bash "$SCRIPT" <<< "$input")
     visible=$(strip_ansi "$result")
     len=$(printf '%s' "$visible" | wc -m | tr -d ' ')
     [ "$len" -le 40 ]
-    [[ "$visible" == *"Claude"* ]]
-    [[ "$visible" == *"proj"* ]]
+    [[ "$visible" == *"myproject"* ]]
+    # Model name is lowest priority — truncated first in narrow terminals
+    [[ "$visible" != *"Claude 3.5 Sonnet"* ]]
 }
 
 @test "wide terminal shows session_id" {

--- a/tests/node/statusline.test.js
+++ b/tests/node/statusline.test.js
@@ -223,8 +223,9 @@ describe('statusline.js', () => {
             expect(result.code).toBe(0);
             const visible = stripAnsi(result.stdout);
             expect(visible.length).toBeLessThanOrEqual(40);
-            expect(visible).toContain('Claude 3.5 Sonnet');
             expect(visible).toContain('myproject');
+            // Model name is lowest priority — truncated first in narrow terminals
+            expect(visible).not.toContain('Claude 3.5 Sonnet');
         });
 
         test('wide terminal shows all', async () => {

--- a/tests/python/test_statusline.py
+++ b/tests/python/test_statusline.py
@@ -192,13 +192,14 @@ class TestWidthTruncation:
         assert len(visible) <= 80
 
     def test_output_fits_narrow_terminal(self, sample_input):
-        """Output should fit within 40 columns and still show model+dir."""
+        """Output should fit within 40 columns, preserving dir and context over model."""
         output, code = run_script(sample_input, {"COLUMNS": "40"})
         assert code == 0
         visible = strip_ansi(output)
         assert len(visible) <= 40
-        assert "Claude 3.5 Sonnet" in visible
         assert "myproject" in visible
+        # Model name is lowest priority — truncated first in narrow terminals
+        assert "Claude 3.5 Sonnet" not in visible
 
     def test_wide_terminal_shows_all(self, sample_input):
         """Wide terminal should show session_id."""


### PR DESCRIPTION
Closes #25

## Summary

Reorders the statusline field layout so that critical context information (project name, git branch, free tokens) appears before the model name. The model name is now the lowest-priority field — it is the first to be truncated when the terminal window is narrow or the git branch name is long.

## Approach

Split `base` (which previously combined model + directory into one indivisible string) into two separate parts: `base` (directory only, always shown) and `model_info` (model name, lowest priority). Reordered the `parts` array so model appears near the end, just before session ID.

**New field order:** directory | branch | context length | zone | MI | delta | **model** | session

## Changes

| File | Change |
|------|--------|
| `src/claude_statusline/cli/statusline.py` | Split base, add model_info, reorder parts array |
| `scripts/statusline.py` | Same changes (standalone Python) |
| `scripts/statusline.js` | Same changes (Node.js) |
| `scripts/statusline-full.sh` | Same changes (Bash) |
| `tests/python/test_statusline.py` | Update narrow terminal test to expect model truncated |
| `tests/node/statusline.test.js` | Update narrow terminal test to expect model truncated |
| `tests/bash/test_statusline_full.bats` | Update narrow terminal test to expect model truncated |

## Test Results

- 264 Python tests passed
- 75 Node.js tests passed
- 65 Bash tests passed

## Acceptance Criteria

- [x] Statusline field order is updated so context length/remaining appears before model name across all implementations
- [x] Model name is moved to the lowest-priority position — first field truncated when terminal is narrow
- [x] When terminal width is insufficient, critical info (context length, project name, branch name) is preserved while model name is omitted
- [x] All four implementations (package `src/`, standalone `scripts/statusline.py`, `scripts/statusline.js`, `scripts/statusline-full.sh`) reflect the new field order consistently