### PR TITLE
Unify context info and zone indicator colors using traffic-light standard

### DIFF
--- a/scripts/statusline.js
+++ b/scripts/statusline.js
@@ -571,21 +571,18 @@ process.stdin.on('end', () => {
             ? freeTokens.toLocaleString('en-US')
             : `${(freeTokens / 1000).toFixed(1)}k`;
 
-        // Color based on MI thresholds (consistent with MI display)
-        const ctxUtil = totalSize > 0 ? usedTokens / totalSize : 0;
-        const ctxMI = computeMI(usedTokens, totalSize, modelId, miCurveBeta);
-        const ctxColor = getMIColor(ctxMI.mi, ctxUtil, cGreen, cYellow, cRed);
+        // Zone indicator — determines color for both context info and zone label
+        const zoneResult = getContextZone(usedTokens, totalSize);
+        const zoneAnsi = zoneAnsiColor(zoneResult.colorName);
 
-        // Use per-property context_length color if configured, else MI-based color
-        const effectiveCtxColor = c.context_length || ctxColor;
+        // Context info uses zone color (traffic-light), with per-property override
+        const effectiveCtxColor = c.context_length || zoneAnsi;
 
         contextInfo = ` | ${effectiveCtxColor}${freeDisplay} (${freePct.toFixed(1)}%)${RESET}`;
 
-        // Always show zone indicator
-        const zoneResult = getContextZone(usedTokens, totalSize);
-        // Use per-property zone color if configured, else dynamic zone color
-        const zoneAnsi = c.zone || zoneAnsiColor(zoneResult.colorName);
-        zoneInfo = ` | ${zoneAnsi}${zoneResult.zone}${RESET}`;
+        // Zone label uses same color, with per-property override
+        const effectiveZoneColor = c.zone || zoneAnsi;
+        zoneInfo = ` | ${effectiveZoneColor}${zoneResult.zone}${RESET}`;
 
         // Read previous entry if needed for delta OR MI
         if (showDelta || showMI) {

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -511,24 +511,18 @@ def main():
         else:
             free_display = f"{free_tokens / 1000:.1f}k"
 
-        # Color based on MI thresholds (consistent with MI display)
-        ctx_util = used_tokens / total_size if total_size > 0 else 0.0
-        ctx_mi = compute_mi(used_tokens, total_size, model_id, mi_curve_beta)
-        ctx_color = get_mi_color(ctx_mi, ctx_util)
+        # Zone indicator — determines color for both context info and zone label
+        zone_word, zone_color_name = get_context_zone(used_tokens, total_size)
+        zone_ansi = _zone_ansi_color(zone_color_name)
 
-        # Use per-property context_length color if configured, else MI-based color
-        effective_ctx_color = c.get("context_length", ctx_color)
+        # Context info uses zone color (traffic-light), with per-property override
+        effective_ctx_color = c.get("context_length", zone_ansi)
 
         context_info = f" | {effective_ctx_color}{free_display} ({free_pct:.1f}%){RESET}"
 
-        # Always show zone indicator
-        zone_word, zone_color_name = get_context_zone(used_tokens, total_size)
-        # Use per-property zone color if configured, else dynamic zone color
-        if "zone" in c:
-            zone_ansi = c["zone"]
-        else:
-            zone_ansi = _zone_ansi_color(zone_color_name)
-        zone_info = f" | {zone_ansi}{zone_word}{RESET}"
+        # Zone label uses same color, with per-property override
+        effective_zone_color = c.get("zone", zone_ansi)
+        zone_info = f" | {effective_zone_color}{zone_word}{RESET}"
 
         # Read previous entry if needed for delta OR MI
         if show_delta or show_mi:

--- a/src/claude_statusline/cli/statusline.py
+++ b/src/claude_statusline/cli/statusline.py
@@ -100,39 +100,31 @@ def main() -> None:
         # Format tokens based on token_detail setting
         free_display = format_tokens(free_tokens, config.token_detail)
 
-        # Color based on MI thresholds (consistent with MI display)
-        from claude_statusline.graphs.intelligence import get_mi_color as _get_ctx_color, calculate_context_pressure, get_model_profile
-
-        _utilization = used_tokens / total_size if total_size > 0 else 0.0
-        _beta = get_model_profile(model_id)
-        _mi = calculate_context_pressure(_utilization, _beta)
-        ctx_color_name = _get_ctx_color(_mi, _utilization)
-        ctx_color = getattr(colors, ctx_color_name)
-
-        # Use per-property context_length color if configured, else MI-based color
-        prop_ctx_color = config.color_overrides.get("context_length")
-        effective_ctx_color = prop_ctx_color if prop_ctx_color else ctx_color
-
-        context_info = f" | {effective_ctx_color}{free_display} ({free_pct:.1f}%){colors.reset}"
-
-        # Always show zone indicator
+        # Zone indicator — determines color for both context info and zone label
         from claude_statusline.graphs.intelligence import get_context_zone
 
         zone_result = get_context_zone(used_tokens, total_size)
-        # Use per-property zone color if configured, else dynamic zone color
+
+        # Traffic-light color map: green/yellow/orange/red/gray
+        zone_color_map = {
+            "green": colors.green,
+            "yellow": colors.yellow,
+            "orange": "\033[38;2;255;165;0m" if colors.enabled else "",
+            "dark_red": "\033[38;2;139;0;0m" if colors.enabled else "",
+            "gray": "\033[0;90m" if colors.enabled else "",
+        }
+        zone_color = zone_color_map.get(zone_result.color, colors.reset)
+
+        # Context info uses zone color (traffic-light), with per-property override
+        prop_ctx_color = config.color_overrides.get("context_length")
+        effective_ctx_color = prop_ctx_color if prop_ctx_color else zone_color
+
+        context_info = f" | {effective_ctx_color}{free_display} ({free_pct:.1f}%){colors.reset}"
+
+        # Zone label uses same color, with per-property override
         prop_zone_color = config.color_overrides.get("zone")
-        if prop_zone_color:
-            zone_color = prop_zone_color
-        else:
-            zone_color_map = {
-                "green": colors.green,
-                "yellow": colors.yellow,
-                "orange": "\033[38;2;255;165;0m" if colors.enabled else "",
-                "dark_red": "\033[38;2;139;0;0m" if colors.enabled else "",
-                "gray": "\033[0;90m" if colors.enabled else "",
-            }
-            zone_color = zone_color_map.get(zone_result.color, colors.reset)
-        zone_info = f" | {zone_color}{zone_result.zone}{colors.reset}"
+        effective_zone_color = prop_zone_color if prop_zone_color else zone_color
+        zone_info = f" | {effective_zone_color}{zone_result.zone}{colors.reset}"
 
         # State file management for delta display and history recording
         if config.show_delta or config.show_mi:


### PR DESCRIPTION
Closes #28

## Summary

Context info (free tokens / percentage) and zone indicator (Plan/Code/Dump/ExDump/Dead) now share the same traffic-light color, giving a unified at-a-glance signal of context health.

Previously, context info used a 3-color MI-based scheme (green/yellow/red) while the zone indicator used a 5-color traffic-light scheme (green/yellow/orange/dark_red/gray). This created visual inconsistency — the two adjacent elements could show different colors for the same context state.

## Approach

Replaced the MI-based `get_mi_color()` call for context info coloring with the zone-based color from `get_context_zone()` across all three implementations. The zone color map (green/yellow/orange/dark_red/gray) is now the single source of truth for both elements.

## Changes

| File | Change |
|------|--------|
| `src/claude_statusline/cli/statusline.py` | Context info uses zone color instead of MI color |
| `scripts/statusline.py` | Same change for standalone Python |
| `scripts/statusline.js` | Same change for Node.js |

Per-property color overrides (`color_context_length`, `color_zone`) continue to work — they override the traffic-light default when configured.

## Test Results

- Python: 263 passed (1 pre-existing failure in `test_explain_no_color_flag` — unrelated)
- Node.js: 75 passed
- Bash: 65 passed

## Acceptance Criteria

- [x] Context info text and zone indicator label use the same color for each zone across all three implementations
- [x] Colors follow the traffic-light standard: green (Plan), yellow (Code), orange (Dump), red (ExDump), gray (Dead)
- [x] Color mapping is consistent between Python package, standalone Python, and Node.js implementations
- [x] Existing user color overrides in `~/.claude/statusline.conf` are respected when configured, with traffic-light as the new default