### PR TITLE
feat(compaction): detect /compact events and flag MI quality (#62 + #65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ The following logic is duplicated between the installable package (`src/`) and t
 | Zone indicator | `graphs/intelligence.py:get_context_zone()` | `get_context_zone()` |
 | Zone constants | `ZONE_1M_*`, `ZONE_STD_*`, `LARGE_MODEL_THRESHOLD` | same |
 | Per-property colors | `colors.py:ColorManager` props, `config.py:_COLOR_KEYS` | `_COLOR_KEYS`, per-property vars |
+| Compaction detection | `graphs/statistics.py:detect_compaction_events()` | `detect_compaction_events()` |
+| Compaction constants | `core/config.py:compaction_drop_threshold`, `compact_mi_warn_threshold` | `COMPACTION_DROP_THRESHOLD`, `COMPACT_MI_WARN_THRESHOLD` |
 
 ## Cross-References
 

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -66,6 +66,10 @@ ZONE_STD_WARN_BUFFER = 30_000
 ZONE_STD_HARD_LIMIT = 0.70
 ZONE_STD_DEAD_ZONE = 0.75
 
+# Compaction detection defaults
+COMPACTION_DROP_THRESHOLD = 0.5   # fraction of context that must be lost to count as compaction
+COMPACT_MI_WARN_THRESHOLD = 0.6   # MI below this at compact time → warning
+
 # Zone recommendation strings — one-line action guidance per zone
 _ZONE_RECOMMENDATIONS = {
     "Plan": "Safe to plan and code",
@@ -161,6 +165,33 @@ def get_context_zone(used_tokens, context_window_size, zone_config=None):
     if used_tokens < dead_zone_tokens:
         return ("ExDump", "dark_red", _ZONE_RECOMMENDATIONS["ExDump"])
     return ("Dead", "gray", _ZONE_RECOMMENDATIONS["Dead"])
+
+
+def detect_compaction_events(values, drop_threshold=None):
+    """Detect compaction events in a list of token counts.
+
+    A compaction event is identified when ``values[i] < values[i-1] * (1 - drop_threshold)``,
+    i.e., the context dropped by more than *drop_threshold* fraction in a single step.
+
+    Args:
+        values: Sequence of token counts (e.g., current_used_tokens over time).
+        drop_threshold: Fraction of context that must be lost to qualify as compaction
+                        (default: COMPACTION_DROP_THRESHOLD = 0.5).
+
+    Returns:
+        List of indices i (into values) where a compaction was detected.
+    """
+    if drop_threshold is None:
+        drop_threshold = COMPACTION_DROP_THRESHOLD
+    if len(values) < 2:
+        return []
+    events = []
+    for i in range(1, len(values)):
+        prev = values[i - 1]
+        curr = values[i]
+        if prev > 0 and curr < prev * (1.0 - drop_threshold):
+            events.append(i)
+    return events
 
 
 def _zone_ansi_color(color_name):
@@ -390,6 +421,8 @@ def read_config():
         "mi_curve_beta": 0.0,
         "colors": {},
         "zone_config": {},
+        "compaction_drop_threshold": COMPACTION_DROP_THRESHOLD,
+        "compact_mi_warn_threshold": COMPACT_MI_WARN_THRESHOLD,
     }
     config_path = os.path.expanduser("~/.claude/statusline.conf")
 
@@ -664,6 +697,20 @@ color_separator=dim
                         v = float(raw_value)
                         if 0.0 < v < 1.0:
                             config["zone_config"][key] = v
+                        else:
+                            sys.stderr.write(
+                                f"[statusline] warning: {key} must be between 0 and 1, "
+                                f"ignoring '{raw_value}'\n"
+                            )
+                    except ValueError:
+                        sys.stderr.write(
+                            f"[statusline] warning: invalid number for {key}: '{raw_value}'\n"
+                        )
+                elif key in ("compaction_drop_threshold", "compact_mi_warn_threshold"):
+                    try:
+                        v = float(raw_value)
+                        if 0.0 < v < 1.0:
+                            config[key] = v
                         else:
                             sys.stderr.write(
                                 f"[statusline] warning: {key} must be between 0 and 1, "

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -67,8 +67,8 @@ ZONE_STD_HARD_LIMIT = 0.70
 ZONE_STD_DEAD_ZONE = 0.75
 
 # Compaction detection defaults
-COMPACTION_DROP_THRESHOLD = 0.5   # fraction of context that must be lost to count as compaction
-COMPACT_MI_WARN_THRESHOLD = 0.6   # MI below this at compact time → warning
+COMPACTION_DROP_THRESHOLD = 0.5  # fraction of context that must be lost to count as compaction
+COMPACT_MI_WARN_THRESHOLD = 0.6  # MI below this at compact time → warning
 
 # Zone recommendation strings — one-line action guidance per zone
 _ZONE_RECOMMENDATIONS = {

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -33,7 +33,7 @@ from claude_statusline.core.colors import ColorManager
 from claude_statusline.core.config import Config
 from claude_statusline.core.state import StateFile, _validate_session_id
 from claude_statusline.graphs.renderer import GraphDimensions, GraphRenderer
-from claude_statusline.graphs.statistics import calculate_deltas
+from claude_statusline.graphs.statistics import calculate_deltas, detect_compaction_events
 from claude_statusline.ui.icons import get_activity_tier, get_tier_label
 from claude_statusline.ui.waiting import get_waiting_text, is_active
 
@@ -376,10 +376,22 @@ def render_once(
     if watch_mode:
         renderer.begin_buffering()
 
+    # Load config for compaction and MI settings
+    mi_config = config if config else Config.load()
+
+    # Detect compaction events upfront so markers are available for graph rendering
+    compaction_indices = detect_compaction_events(
+        context_used, mi_config.compaction_drop_threshold
+    )
+
     # Render requested graphs
     if graph_type in ("cumulative", "both", "all"):
         renderer.render_timeseries(
-            context_used, timestamps, "Context Usage Over Time", colors.green
+            context_used,
+            timestamps,
+            "Context Usage Over Time",
+            colors.green,
+            compaction_indices=compaction_indices if compaction_indices else None,
         )
 
     if graph_type in ("delta", "both", "all"):
@@ -408,7 +420,6 @@ def render_once(
     if entries:
         from claude_statusline.graphs.intelligence import calculate_intelligence
 
-        mi_config = config if config else Config.load()
         beta = mi_config.mi_curve_beta
 
         if graph_type in ("mi", "all"):
@@ -435,6 +446,20 @@ def render_once(
             last = entries[-1]
             mi_score = calculate_intelligence(last, last.context_window_size, last.model_id, beta)
 
+    # Compute MI at each compaction point for quality assessment (#65)
+    compaction_events: list[tuple[int, float]] = []
+    if compaction_indices and entries:
+        from claude_statusline.graphs.intelligence import calculate_intelligence
+
+        beta = mi_config.mi_curve_beta
+        for ci in compaction_indices:
+            if ci < len(entries):
+                entry = entries[ci]
+                score = calculate_intelligence(
+                    entry, entry.context_window_size, entry.model_id, beta
+                )
+                compaction_events.append((ci, score.mi))
+
     # Summary and footer
     from claude_statusline.cli.cache_warm import _warm_state_path, is_cache_warm_active
 
@@ -451,6 +476,8 @@ def render_once(
         mi_score=mi_score,
         graph_type=graph_type,
         cache_warm_status=cache_warm_status,
+        compaction_events=compaction_events or None,
+        compact_mi_warn_threshold=mi_config.compact_mi_warn_threshold,
     )
     renderer.render_footer(__version__)
 

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -380,9 +380,7 @@ def render_once(
     mi_config = config if config else Config.load()
 
     # Detect compaction events upfront so markers are available for graph rendering
-    compaction_indices = detect_compaction_events(
-        context_used, mi_config.compaction_drop_threshold
-    )
+    compaction_indices = detect_compaction_events(context_used, mi_config.compaction_drop_threshold)
 
     # Render requested graphs
     if graph_type in ("cumulative", "both", "all"):

--- a/src/claude_statusline/cli/report.py
+++ b/src/claude_statusline/cli/report.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import argparse
 import sys
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from claude_statusline import __version__
@@ -117,8 +117,16 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
         scope_from = cutoff.strftime("%Y-%m-%d")
     else:
         all_start_times = [s.start_time for s in all_sessions if s.start_time > 0]
-        scope_from = datetime.fromtimestamp(min(all_start_times)).strftime("%Y-%m-%d") if all_start_times else "unknown"
-    scope_to = datetime.fromtimestamp(max(all_end_times)).strftime("%Y-%m-%d") if all_end_times else "unknown"
+        scope_from = (
+            datetime.fromtimestamp(min(all_start_times)).strftime("%Y-%m-%d")
+            if all_start_times
+            else "unknown"
+        )
+    scope_to = (
+        datetime.fromtimestamp(max(all_end_times)).strftime("%Y-%m-%d")
+        if all_end_times
+        else "unknown"
+    )
     time_scope = f"{scope_from} → {scope_to}"
 
     # Header
@@ -167,7 +175,7 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
 
     # Mermaid pie chart: model cost distribution
     lines.append("```mermaid")
-    lines.append('pie title Model Cost Distribution')
+    lines.append("pie title Model Cost Distribution")
     for fam in ("opus", "sonnet", "haiku", "other"):
         if fam not in model_stats:
             continue
@@ -212,10 +220,7 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     real_cache_read = sum(s.total_cache_read for s in real_sessions)
     real_total_tokens = sum(s.total_tokens() for s in real_sessions)
     real_cache_pct = real_cache_read / real_total_tokens * 100 if real_total_tokens > 0 else 0
-    lines.append(
-        f"- **Cache Hit Ratio**: {real_cache_pct:.1f}% "
-        f"(room for improvement if <70%)"
-    )
+    lines.append(f"- **Cache Hit Ratio**: {real_cache_pct:.1f}% (room for improvement if <70%)")
 
     cost_per_1k = total_cost / (total_tokens / 1000) if total_tokens > 0 else 0
     lines.append(f"\n- **Cost per 1k tokens**: ${cost_per_1k:.3f}")
@@ -241,10 +246,7 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     lines.append("")
 
     # Low cache sessions (cache < 10%, non-fake, min cost threshold)
-    low_cache = [
-        s for s in real_sessions
-        if s.cache_hit_ratio() < 10 and s.total_tokens() > 10000
-    ]
+    low_cache = [s for s in real_sessions if s.cache_hit_ratio() < 10 and s.total_tokens() > 10000]
     low_cache_sorted = sorted(low_cache, key=lambda s: s.cache_hit_ratio())[:5]
     if low_cache_sorted:
         lines.append(
@@ -254,7 +256,9 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
         lines.append("")
         for s in low_cache_sorted:
             proj_name = s.project_dir.split("/")[-1] if "/" in s.project_dir else s.project_dir
-            lines.append(f"     - {s.session_id[:8]}... ({proj_name}): {int(s.cache_hit_ratio())}% cache hit")
+            lines.append(
+                f"     - {s.session_id[:8]}... ({proj_name}): {int(s.cache_hit_ratio())}% cache hit"
+            )
         lines.append("")
 
     # Model efficiency
@@ -286,8 +290,8 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     top5_proj = sorted(projects_stats, key=lambda p: p.cost_usd, reverse=True)[:5]
     proj_labels = [f'"{p.project_name()[:8]}"' for p in top5_proj]
     proj_costs = [f"{p.cost_usd:.2f}" for p in top5_proj]
-    lines.append(f'    x-axis [{", ".join(proj_labels)}]')
-    lines.append(f'    bar [{", ".join(proj_costs)}]')
+    lines.append(f"    x-axis [{', '.join(proj_labels)}]")
+    lines.append(f"    bar [{', '.join(proj_costs)}]")
     lines.append("```")
     lines.append("")
 
@@ -301,13 +305,15 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
 
     # Mermaid pie chart: cache vs fresh tokens
     lines.append("```mermaid")
-    lines.append('pie title Token Serving: Cache vs Fresh')
+    lines.append("pie title Token Serving: Cache vs Fresh")
     lines.append(f'    "Cache Hit" : {cache_tokens_pct:.1f}')
     lines.append(f'    "Fresh (non-cached)" : {fresh_tokens_pct:.1f}')
     lines.append("```")
     lines.append("")
 
-    lines.append(f"- **Overall cache efficiency**: {cache_tokens_pct:.1f}% of tokens served from cache")
+    lines.append(
+        f"- **Overall cache efficiency**: {cache_tokens_pct:.1f}% of tokens served from cache"
+    )
     lines.append(f"- **Average tokens per dollar**: {int(avg_tokens_per_dollar)} tokens/$")
     lines.append("")
 
@@ -365,8 +371,8 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     lines.append('    title "Sessions by Day of Week"')
     dow_labels = [f'"{d}"' for d in day_names]
     dow_values = [str(dow_counts.get(i, 0)) for i in range(7)]
-    lines.append(f'    x-axis [{", ".join(dow_labels)}]')
-    lines.append(f'    bar [{", ".join(dow_values)}]')
+    lines.append(f"    x-axis [{', '.join(dow_labels)}]")
+    lines.append(f"    bar [{', '.join(dow_values)}]")
     lines.append("```")
     lines.append("")
 
@@ -385,8 +391,8 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     lines.append('    title "Sessions by Hour of Day"')
     hour_labels = [f'"{h:02d}h"' for h in range(24)]
     hour_values = [str(hour_counts.get(h, 0)) for h in range(24)]
-    lines.append(f'    x-axis [{", ".join(hour_labels)}]')
-    lines.append(f'    bar [{", ".join(hour_values)}]')
+    lines.append(f"    x-axis [{', '.join(hour_labels)}]")
+    lines.append(f"    bar [{', '.join(hour_values)}]")
     lines.append("```")
     lines.append("")
 
@@ -421,8 +427,8 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     lines.append("```mermaid")
     lines.append("xychart-beta")
     lines.append('    title "Weekly Spend ($)"')
-    lines.append(f'    x-axis [{", ".join(short_week_labels)}]')
-    lines.append(f'    line [{", ".join(week_costs)}]')
+    lines.append(f"    x-axis [{', '.join(short_week_labels)}]")
+    lines.append(f"    line [{', '.join(week_costs)}]")
     lines.append("```")
     lines.append("")
 
@@ -430,8 +436,8 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     lines.append("```mermaid")
     lines.append("xychart-beta")
     lines.append('    title "Weekly Sessions Count"')
-    lines.append(f'    x-axis [{", ".join(short_week_labels)}]')
-    lines.append(f'    bar [{", ".join(week_session_counts)}]')
+    lines.append(f"    x-axis [{', '.join(short_week_labels)}]")
+    lines.append(f"    bar [{', '.join(week_session_counts)}]")
     lines.append("```")
     lines.append("")
 
@@ -484,9 +490,7 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
         for proj_dir, pd in top_efficient_proj:
             proj_name = proj_dir.split("/")[-1] if "/" in proj_dir else proj_dir
             eff = int(pd["lines"] / pd["cost"]) if pd["cost"] > 0 else 0
-            lines.append(
-                f"| {proj_name} | {pd['lines']:,} | ${pd['cost']:.2f} | {eff} |"
-            )
+            lines.append(f"| {proj_name} | {pd['lines']:,} | ${pd['cost']:.2f} | {eff} |")
         lines.append("")
 
     # Projects summary table
@@ -495,7 +499,9 @@ def generate_report(projects_stats: list[ProjectStats], since_days: int | None =
     lines.append(
         "| # | Project | Sessions | Cost | % Total | Tokens | Cache Hit % | Avg Cost | Dominant Model |"
     )
-    lines.append("|---|---------|----------|------|---------|--------|-------------|----------|----------------|")
+    lines.append(
+        "|---|---------|----------|------|---------|--------|-------------|----------|----------------|"
+    )
     for idx, p in enumerate(projects_stats, 1):
         pct = p.cost_usd / total_cost * 100 if total_cost > 0 else 0
         avg_cost = p.cost_usd / p.session_count if p.session_count > 0 else 0

--- a/src/claude_statusline/core/config.py
+++ b/src/claude_statusline/core/config.py
@@ -44,6 +44,12 @@ _ZONE_FLOAT_KEYS: set[str] = {
     "zone_std_dead_ratio",
 }
 
+# Compaction-related float config keys (fractions in (0, 1))
+_COMPACTION_FLOAT_KEYS: set[str] = {
+    "compaction_drop_threshold",
+    "compact_mi_warn_threshold",
+}
+
 
 # ---------------------------------------------------------------------------
 # Default config template — loaded at runtime from package data
@@ -105,6 +111,10 @@ class Config:
     zone_std_hard_limit: float = 0.0
     zone_std_dead_ratio: float = 0.0
     large_model_threshold: int = 0
+
+    # Compaction detection settings
+    compaction_drop_threshold: float = 0.5  # drop fraction to qualify as compaction
+    compact_mi_warn_threshold: float = 0.6  # MI below this at compact time → warning
 
     # Custom color overrides (slot_name -> ANSI code)
     color_overrides: dict[str, str] = field(default_factory=dict)
@@ -212,6 +222,20 @@ class Config:
                         sys.stderr.write(
                             f"[statusline] warning: invalid number for {key}: '{raw_value}'\n"
                         )
+                elif key in _COMPACTION_FLOAT_KEYS:
+                    try:
+                        v = float(raw_value)
+                        if 0.0 < v < 1.0:
+                            setattr(self, key, v)
+                        else:
+                            sys.stderr.write(
+                                f"[statusline] warning: {key} must be between 0 and 1, "
+                                f"ignoring '{raw_value}'\n"
+                            )
+                    except ValueError:
+                        sys.stderr.write(
+                            f"[statusline] warning: invalid number for {key}: '{raw_value}'\n"
+                        )
                 elif key in _COLOR_KEYS:
                     slot = _COLOR_KEYS[key]
                     ansi = parse_color(raw_value)
@@ -248,4 +272,6 @@ class Config:
             "zone_std_dead_ratio": self.zone_std_dead_ratio,
             "large_model_threshold": self.large_model_threshold,
             "color_overrides": dict(self.color_overrides),
+            "compaction_drop_threshold": self.compaction_drop_threshold,
+            "compact_mi_warn_threshold": self.compact_mi_warn_threshold,
         }

--- a/src/claude_statusline/graphs/intelligence.py
+++ b/src/claude_statusline/graphs/intelligence.py
@@ -70,6 +70,7 @@ class ZoneInfo:
     label: str  # Human-readable label
     recommendation: str  # One-line action guidance for the user
 
+
 # Zone recommendation strings — one per zone
 _ZONE_RECOMMENDATIONS: dict[str, str] = {
     "Plan": "Safe to plan and code",
@@ -202,7 +203,9 @@ def get_context_zone(
     """
     if context_window_size == 0:
         return ZoneInfo(
-            zone="Plan", color="green", label="Planning",
+            zone="Plan",
+            color="green",
+            label="Planning",
             recommendation=_ZONE_RECOMMENDATIONS["Plan"],
         )
 
@@ -218,26 +221,36 @@ def get_context_zone(
 
         if used_tokens < p_max:
             return ZoneInfo(
-                zone="Plan", color="green", label="Planning",
+                zone="Plan",
+                color="green",
+                label="Planning",
                 recommendation=_ZONE_RECOMMENDATIONS["Plan"],
             )
         if used_tokens < c_max:
             return ZoneInfo(
-                zone="Code", color="yellow", label="Code-only",
+                zone="Code",
+                color="yellow",
+                label="Code-only",
                 recommendation=_ZONE_RECOMMENDATIONS["Code"],
             )
         if used_tokens < d_max:
             return ZoneInfo(
-                zone="Dump", color="orange", label="Dump zone",
+                zone="Dump",
+                color="orange",
+                label="Dump zone",
                 recommendation=_ZONE_RECOMMENDATIONS["Dump"],
             )
         if used_tokens < x_max:
             return ZoneInfo(
-                zone="ExDump", color="dark_red", label="Hard limit",
+                zone="ExDump",
+                color="dark_red",
+                label="Hard limit",
                 recommendation=_ZONE_RECOMMENDATIONS["ExDump"],
             )
         return ZoneInfo(
-            zone="Dead", color="gray", label="Dead zone",
+            zone="Dead",
+            color="gray",
+            label="Dead zone",
             recommendation=_ZONE_RECOMMENDATIONS["Dead"],
         )
 
@@ -254,26 +267,36 @@ def get_context_zone(
 
     if used_tokens < warn_start:
         return ZoneInfo(
-            zone="Plan", color="green", label="Planning",
+            zone="Plan",
+            color="green",
+            label="Planning",
             recommendation=_ZONE_RECOMMENDATIONS["Plan"],
         )
     if used_tokens < dump_zone_tokens:
         return ZoneInfo(
-            zone="Code", color="yellow", label="Code-only",
+            zone="Code",
+            color="yellow",
+            label="Code-only",
             recommendation=_ZONE_RECOMMENDATIONS["Code"],
         )
     if used_tokens < hard_limit_tokens:
         return ZoneInfo(
-            zone="Dump", color="orange", label="Dump zone",
+            zone="Dump",
+            color="orange",
+            label="Dump zone",
             recommendation=_ZONE_RECOMMENDATIONS["Dump"],
         )
     if used_tokens < dead_zone_tokens:
         return ZoneInfo(
-            zone="ExDump", color="dark_red", label="Hard limit",
+            zone="ExDump",
+            color="dark_red",
+            label="Hard limit",
             recommendation=_ZONE_RECOMMENDATIONS["ExDump"],
         )
     return ZoneInfo(
-        zone="Dead", color="gray", label="Dead zone",
+        zone="Dead",
+        color="gray",
+        label="Dead zone",
         recommendation=_ZONE_RECOMMENDATIONS["Dead"],
     )
 

--- a/src/claude_statusline/graphs/renderer.py
+++ b/src/claude_statusline/graphs/renderer.py
@@ -89,6 +89,9 @@ class GraphRenderer:
         else:
             print(line)
 
+    # Compaction event marker character
+    COMPACTION_MARKER = "▼"
+
     def render_timeseries(
         self,
         data: list[int],
@@ -96,6 +99,7 @@ class GraphRenderer:
         title: str,
         color: str,
         label_fn: Callable[[int], str] | None = None,
+        compaction_indices: list[int] | None = None,
     ) -> None:
         """Render a timeseries ASCII graph.
 
@@ -105,7 +109,10 @@ class GraphRenderer:
             title: Graph title
             color: ANSI color code for the graph
             label_fn: Optional function to format Y-axis labels. If None, uses format_tokens().
-        """
+            compaction_indices: Optional list of indices (into *data*) where a compaction
+                                event was detected. A ``▼`` marker is drawn at those
+                                x-positions using the orange color.
+"""
         n = len(data)
         if n == 0:
             return
@@ -137,6 +144,21 @@ class GraphRenderer:
         # Build the graph grid
         grid = self._build_grid(data, min_val, max_val, value_range, width, height)
 
+        # Overlay compaction markers (▼) in orange at the detected event positions
+        # Orange ANSI color for the compaction marker
+        _ORANGE = "\033[38;2;255;165;0m"
+        compaction_x_positions: set[int] = set()
+        if compaction_indices:
+            for ci in compaction_indices:
+                if 0 <= ci < n:
+                    # Map data index to x-coordinate (same formula as _build_grid)
+                    if n == 1:
+                        cx = width // 2
+                    else:
+                        cx = int(ci * (width - 1) / (n - 1))
+                    cx = max(0, min(width - 1, cx))
+                    compaction_x_positions.add(cx)
+
         # Print grid with Y-axis labels
         for r in range(height):
             val = max_val - r * value_range // (height - 1)
@@ -148,6 +170,16 @@ class GraphRenderer:
                 label = ""
 
             row_data = grid[r] if r < len(grid) else " " * width
+
+            # Inject compaction markers into the row string when needed.
+            # We place the marker at the top row (r == 0) so it's always visible.
+            if compaction_x_positions and r == 0:
+                row_chars = list(row_data)
+                for cx in compaction_x_positions:
+                    if cx < len(row_chars):
+                        row_chars[cx] = f"{_ORANGE}{self.COMPACTION_MARKER}{color}"
+                row_data = "".join(row_chars)
+
             self._emit(
                 f"{label:>10} {self.colors.dim}│{self.colors.reset}"
                 f"{color}{row_data}{self.colors.reset}"
@@ -267,6 +299,8 @@ class GraphRenderer:
         mi_score: object | None = None,  # IntelligenceScore
         graph_type: str | None = None,
         cache_warm_status: tuple[bool, int] | None = None,
+        compaction_events: list[tuple[int, float]] | None = None,
+        compact_mi_warn_threshold: float = 0.6,
     ) -> None:
         """Render summary statistics.
 
@@ -276,6 +310,10 @@ class GraphRenderer:
             mi_score: Optional IntelligenceScore for MI display
             graph_type: Graph type being displayed
             cache_warm_status: Optional (active, seconds_remaining) from cache_warm module
+            compaction_events: Optional list of ``(entry_index, mi_at_compact)`` tuples
+                               for each detected compaction event.
+            compact_mi_warn_threshold: MI threshold below which a compaction is flagged
+                                       as potentially lossy (default: 0.6).
         """
         if not entries:
             return
@@ -352,6 +390,27 @@ class GraphRenderer:
                 f"  {self.colors.dim}  Context: "
                 f"{mi_score.utilization * 100:.0f}% used{self.colors.reset}"
             )
+
+        # Compaction events summary
+        if compaction_events:
+            count = len(compaction_events)
+            self._emit(
+                f"  {self.colors.yellow}{'Compactions:':<20}{self.colors.reset} {count}"
+            )
+            for _idx, mi_at_compact in compaction_events:
+                if mi_at_compact < compact_mi_warn_threshold:
+                    self._emit(
+                        f"  {self.colors.red}  ⚠ Compact at low MI ({mi_at_compact:.2f}){self.colors.reset}"
+                        f"{self.colors.dim} — summary may have missed context{self.colors.reset}"
+                    )
+                    self._emit(
+                        f"  {self.colors.dim}    Tip: use /compact with a focus prompt to guide what gets preserved{self.colors.reset}"
+                    )
+                else:
+                    self._emit(
+                        f"  {self.colors.green}  ✓ Compact at healthy MI ({mi_at_compact:.2f}){self.colors.reset}"
+                        f"{self.colors.dim} — summary likely complete{self.colors.reset}"
+                    )
 
         if last.context_window_size > 0:
             self._emit()

--- a/src/claude_statusline/graphs/renderer.py
+++ b/src/claude_statusline/graphs/renderer.py
@@ -112,7 +112,7 @@ class GraphRenderer:
             compaction_indices: Optional list of indices (into *data*) where a compaction
                                 event was detected. A ``▼`` marker is drawn at those
                                 x-positions using the orange color.
-"""
+        """
         n = len(data)
         if n == 0:
             return
@@ -394,9 +394,7 @@ class GraphRenderer:
         # Compaction events summary
         if compaction_events:
             count = len(compaction_events)
-            self._emit(
-                f"  {self.colors.yellow}{'Compactions:':<20}{self.colors.reset} {count}"
-            )
+            self._emit(f"  {self.colors.yellow}{'Compactions:':<20}{self.colors.reset} {count}")
             for _idx, mi_at_compact in compaction_events:
                 if mi_at_compact < compact_mi_warn_threshold:
                     self._emit(

--- a/src/claude_statusline/graphs/statistics.py
+++ b/src/claude_statusline/graphs/statistics.py
@@ -71,6 +71,41 @@ def detect_spike(deltas: list[int], context_window_size: int, window: int = 5) -
     return False
 
 
+def detect_compaction_events(
+    values: list[int], drop_threshold: float = 0.5
+) -> list[int]:
+    """Detect compaction events in a list of token counts.
+
+    A compaction event is identified when ``values[i] < values[i-1] * (1 - drop_threshold)``,
+    i.e., the context dropped by more than *drop_threshold* fraction in a single step.
+    With the default threshold of 0.5 this means the new value is less than half the old value.
+
+    The parameter ``drop_threshold`` controls what fraction of context must be lost to count
+    as a compaction.  Increasing it makes detection stricter (only very large drops qualify);
+    decreasing it makes it more sensitive.
+
+    Args:
+        values: Sequence of token counts (e.g., ``current_used_tokens`` over time).
+        drop_threshold: Fraction of context that must be lost to qualify as compaction
+                        (default: 0.5, i.e., > 50 % drop).
+
+    Returns:
+        List of indices *i* (into *values*) where a compaction was detected.
+        Indices are 1-based (the earliest possible index is 1).
+    """
+    if len(values) < 2:
+        return []
+
+    events: list[int] = []
+    for i in range(1, len(values)):
+        prev = values[i - 1]
+        curr = values[i]
+        # Guard against zero-division; if prev == 0 there is nothing to compare
+        if prev > 0 and curr < prev * (1.0 - drop_threshold):
+            events.append(i)
+    return events
+
+
 def calculate_deltas(values: list[int]) -> list[int]:
     """Calculate deltas between consecutive values.
 

--- a/src/claude_statusline/graphs/statistics.py
+++ b/src/claude_statusline/graphs/statistics.py
@@ -71,9 +71,7 @@ def detect_spike(deltas: list[int], context_window_size: int, window: int = 5) -
     return False
 
 
-def detect_compaction_events(
-    values: list[int], drop_threshold: float = 0.5
-) -> list[int]:
+def detect_compaction_events(values: list[int], drop_threshold: float = 0.5) -> list[int]:
     """Detect compaction events in a list of token counts.
 
     A compaction event is identified when ``values[i] < values[i-1] * (1 - drop_threshold)``,

--- a/tests/python/test_compaction.py
+++ b/tests/python/test_compaction.py
@@ -1,0 +1,428 @@
+"""Tests for compaction event detection (#62) and MI quality flagging (#65)."""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_statusline.core.colors import ColorManager
+from claude_statusline.core.config import Config
+from claude_statusline.core.state import StateEntry
+from claude_statusline.graphs.intelligence import calculate_intelligence
+from claude_statusline.graphs.renderer import GraphDimensions, GraphRenderer
+from claude_statusline.graphs.statistics import detect_compaction_events
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    current_input: int = 0,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+    context_window_size: int = 200_000,
+    model_id: str = "claude-sonnet-4-6",
+) -> StateEntry:
+    """Factory for StateEntry with sensible defaults."""
+    return StateEntry(
+        timestamp=1_000_000,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        current_input_tokens=current_input,
+        current_output_tokens=0,
+        cache_creation=cache_creation,
+        cache_read=cache_read,
+        cost_usd=0.0,
+        lines_added=0,
+        lines_removed=0,
+        session_id="test-session",
+        model_id=model_id,
+        workspace_project_dir="/test/project",
+        context_window_size=context_window_size,
+    )
+
+
+def _render_summary_with_compaction(
+    entries: list,
+    compaction_events: list[tuple[int, float]] | None,
+    compact_mi_warn_threshold: float = 0.6,
+) -> str:
+    """Render summary with compaction data and return buffered output."""
+    renderer = GraphRenderer(
+        colors=ColorManager(enabled=False),
+        dimensions=GraphDimensions(
+            term_width=120,
+            term_height=40,
+            graph_width=105,
+            graph_height=13,
+        ),
+    )
+    renderer.begin_buffering()
+    renderer.render_summary(
+        entries,
+        deltas=[],
+        compaction_events=compaction_events,
+        compact_mi_warn_threshold=compact_mi_warn_threshold,
+    )
+    return renderer.get_buffer()
+
+
+# ---------------------------------------------------------------------------
+# Class 1: detect_compaction_events
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCompactionEvents:
+    """Unit tests for the detect_compaction_events function."""
+
+    def test_empty_list_returns_empty(self):
+        """An empty token list produces no events."""
+        assert detect_compaction_events([]) == []
+
+    def test_single_value_returns_empty(self):
+        """A single-element list cannot have a compaction."""
+        assert detect_compaction_events([100_000]) == []
+
+    def test_two_equal_values_no_compaction(self):
+        """Identical consecutive values are not compactions."""
+        assert detect_compaction_events([50_000, 50_000]) == []
+
+    def test_growing_context_no_compaction(self):
+        """Monotonically increasing token counts have no compactions."""
+        values = [10_000, 20_000, 40_000, 80_000, 160_000]
+        assert detect_compaction_events(values) == []
+
+    def test_greater_than_50pct_drop_detected(self):
+        """A drop of exactly > 50% is detected (new < old * 0.5)."""
+        # 100k → 49k: 49k < 100k * 0.5 → compaction
+        values = [100_000, 49_000]
+        events = detect_compaction_events(values)
+        assert events == [1]
+
+    def test_exactly_50pct_drop_not_detected(self):
+        """A drop of exactly 50% is NOT a compaction (not strictly less than 50%)."""
+        # 100k → 50k: 50k == 100k * 0.5 → NOT a compaction
+        values = [100_000, 50_000]
+        assert detect_compaction_events(values) == []
+
+    def test_slightly_above_50pct_drop_detected(self):
+        """A drop just above 50% threshold is detected."""
+        # 100k → 49_999: just under the 50k boundary
+        values = [100_000, 49_999]
+        events = detect_compaction_events(values)
+        assert events == [1]
+
+    def test_multiple_compactions(self):
+        """Multiple compaction events in a session are all detected."""
+        values = [
+            100_000,   # index 0: baseline
+            120_000,   # index 1: growth
+            40_000,    # index 2: first compaction (40k < 120k * 0.5 = 60k)
+            60_000,    # index 3: growth
+            10_000,    # index 4: second compaction (10k < 60k * 0.5 = 30k)
+        ]
+        events = detect_compaction_events(values)
+        assert 2 in events
+        assert 4 in events
+        assert len(events) == 2
+
+    def test_zero_previous_value_skipped(self):
+        """If previous token count is 0, the comparison is skipped gracefully."""
+        values = [0, 50_000]
+        assert detect_compaction_events(values) == []
+
+    def test_custom_threshold_60pct(self):
+        """Custom threshold of 0.6 requires > 60% drop."""
+        # 100k → 41k: 41k < 100k * (1 - 0.6) = 40k → NOT a compaction at 60% threshold
+        values = [100_000, 41_000]
+        assert detect_compaction_events(values, drop_threshold=0.6) == []
+
+        # 100k → 39k: 39k < 40k → compaction at 60% threshold
+        values2 = [100_000, 39_000]
+        assert detect_compaction_events(values2, drop_threshold=0.6) == [1]
+
+    def test_custom_threshold_30pct(self):
+        """Sensitive threshold of 0.3 catches smaller drops."""
+        # 100k → 65k: 65k < 100k * 0.7 = 70k → compaction at 30% threshold
+        values = [100_000, 65_000]
+        assert detect_compaction_events(values, drop_threshold=0.3) == [1]
+
+        # Same drop at default 50% threshold → not a compaction
+        assert detect_compaction_events(values) == []
+
+    def test_returns_correct_indices(self):
+        """Returned indices correspond to the position of the post-compaction value."""
+        values = [0, 200_000, 300_000, 80_000, 90_000]
+        # index 3: 80k < 300k * 0.5 = 150k → compaction
+        events = detect_compaction_events(values)
+        assert 3 in events
+
+    def test_gradual_decrease_no_compaction(self):
+        """A gradual token decrease (e.g., 10% at a time) is not a compaction."""
+        values = [100_000, 90_000, 81_000, 72_900]
+        assert detect_compaction_events(values) == []
+
+
+# ---------------------------------------------------------------------------
+# Class 2: MI at compaction (issue #65)
+# ---------------------------------------------------------------------------
+
+
+class TestMiAtCompaction:
+    """Tests for MI quality assessment at compaction points."""
+
+    def test_low_mi_at_compaction_detected(self):
+        """An entry at high context utilization (low MI) gets a warning."""
+        # 90% utilization on a 200k context → very low MI
+        entry = _make_entry(current_input=180_000, context_window_size=200_000)
+        score = calculate_intelligence(entry, 200_000, "claude-sonnet-4-6")
+        assert score.mi < 0.6, f"Expected low MI, got {score.mi:.3f}"
+
+    def test_healthy_mi_at_compaction_no_warning(self):
+        """An entry at low context utilization (high MI) gets a neutral note."""
+        # 20% utilization → healthy MI
+        entry = _make_entry(current_input=40_000, context_window_size=200_000)
+        score = calculate_intelligence(entry, 200_000, "claude-sonnet-4-6")
+        assert score.mi >= 0.6, f"Expected healthy MI, got {score.mi:.3f}"
+
+    def test_mi_threshold_boundary(self):
+        """Entries near the 0.6 MI threshold are correctly classified."""
+        # Find a utilization that gives MI just below 0.6 for sonnet (beta=1.5)
+        # MI = 1 - u^1.5 = 0.6 → u^1.5 = 0.4 → u = 0.4^(2/3) ≈ 0.543
+        entry_low = _make_entry(current_input=120_000, context_window_size=200_000)  # 60%
+        score_low = calculate_intelligence(entry_low, 200_000, "claude-sonnet-4-6")
+        # At 60% (0.6 utilization): MI = 1 - 0.6^1.5 ≈ 1 - 0.465 = 0.535 < 0.6
+        assert score_low.mi < 0.6
+
+        entry_high = _make_entry(current_input=60_000, context_window_size=200_000)  # 30%
+        score_high = calculate_intelligence(entry_high, 200_000, "claude-sonnet-4-6")
+        # At 30% (0.3 utilization): MI = 1 - 0.3^1.5 ≈ 1 - 0.164 = 0.836 > 0.6
+        assert score_high.mi > 0.6
+
+
+# ---------------------------------------------------------------------------
+# Class 3: render_summary with compaction info
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSummaryCompaction:
+    """Tests for compaction summary display in render_summary."""
+
+    def _entries(self):
+        """Create a minimal list of entries for summary rendering."""
+        return [
+            _make_entry(current_input=100_000, context_window_size=200_000),
+            _make_entry(current_input=120_000, context_window_size=200_000),
+        ]
+
+    def test_no_compactions_no_compaction_line(self):
+        """When compaction_events is None, no compaction line is shown."""
+        output = _render_summary_with_compaction(self._entries(), compaction_events=None)
+        assert "Compaction" not in output
+        assert "compact" not in output.lower()
+
+    def test_no_compactions_empty_list(self):
+        """When compaction_events is an empty list, no compaction line is shown."""
+        output = _render_summary_with_compaction(self._entries(), compaction_events=[])
+        assert "Compaction" not in output
+
+    def test_single_compaction_count_shown(self):
+        """When one compaction event exists, count line is shown."""
+        events = [(1, 0.45)]  # low MI compaction
+        output = _render_summary_with_compaction(self._entries(), compaction_events=events)
+        assert "Compactions:" in output
+        assert "1" in output
+
+    def test_multiple_compactions_count_shown(self):
+        """Multiple compaction events show correct count."""
+        events = [(1, 0.45), (3, 0.82)]
+        output = _render_summary_with_compaction(self._entries(), compaction_events=events)
+        assert "Compactions:" in output
+        assert "2" in output
+
+    def test_low_mi_compact_shows_warning(self):
+        """A compaction at low MI (<0.6) shows a warning with the MI value."""
+        events = [(1, 0.43)]
+        output = _render_summary_with_compaction(
+            self._entries(), compaction_events=events, compact_mi_warn_threshold=0.6
+        )
+        assert "0.43" in output
+        # Should include warning symbol or relevant text
+        assert any(keyword in output for keyword in ["missed", "low MI", "⚠"])
+
+    def test_healthy_mi_compact_shows_confirmation(self):
+        """A compaction at healthy MI (>=0.6) shows a confirmation."""
+        events = [(1, 0.82)]
+        output = _render_summary_with_compaction(
+            self._entries(), compaction_events=events, compact_mi_warn_threshold=0.6
+        )
+        assert "0.82" in output
+        assert any(keyword in output for keyword in ["healthy", "complete", "✓"])
+
+    def test_mixed_compactions(self):
+        """Mixed compaction quality shows both warning and confirmation."""
+        events = [(1, 0.43), (3, 0.82)]
+        output = _render_summary_with_compaction(
+            self._entries(), compaction_events=events, compact_mi_warn_threshold=0.6
+        )
+        assert "0.43" in output
+        assert "0.82" in output
+
+    def test_custom_mi_warn_threshold(self):
+        """Custom MI warn threshold changes classification."""
+        # MI 0.65: above default 0.6 → confirmation; below custom 0.7 → warning
+        events = [(1, 0.65)]
+
+        # With default threshold (0.6): MI 0.65 >= 0.6 → confirmation
+        output_default = _render_summary_with_compaction(
+            self._entries(), compaction_events=events, compact_mi_warn_threshold=0.6
+        )
+        assert any(keyword in output_default for keyword in ["healthy", "complete", "✓"])
+
+        # With custom threshold (0.7): MI 0.65 < 0.7 → warning
+        output_custom = _render_summary_with_compaction(
+            self._entries(), compaction_events=events, compact_mi_warn_threshold=0.7
+        )
+        assert any(keyword in output_custom for keyword in ["missed", "low MI", "⚠"])
+
+    def test_at_threshold_boundary(self):
+        """MI exactly at threshold is treated as 'not low' (>=)."""
+        events = [(1, 0.6)]  # exactly at default threshold
+        output = _render_summary_with_compaction(
+            self._entries(), compaction_events=events, compact_mi_warn_threshold=0.6
+        )
+        # 0.6 >= 0.6 → should be confirmation (healthy), not warning
+        assert any(keyword in output for keyword in ["healthy", "complete", "✓"])
+
+
+# ---------------------------------------------------------------------------
+# Class 4: Config parsing for new keys
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionConfig:
+    """Tests for compaction config key parsing."""
+
+    def test_default_drop_threshold(self):
+        """Default compaction_drop_threshold is 0.5."""
+        config = Config()
+        assert config.compaction_drop_threshold == 0.5
+
+    def test_default_mi_warn_threshold(self):
+        """Default compact_mi_warn_threshold is 0.6."""
+        config = Config()
+        assert config.compact_mi_warn_threshold == 0.6
+
+    def test_to_dict_includes_compaction_keys(self):
+        """to_dict includes both new compaction keys."""
+        config = Config()
+        d = config.to_dict()
+        assert "compaction_drop_threshold" in d
+        assert "compact_mi_warn_threshold" in d
+        assert d["compaction_drop_threshold"] == 0.5
+        assert d["compact_mi_warn_threshold"] == 0.6
+
+    def test_parse_valid_drop_threshold(self, tmp_path):
+        """Valid compaction_drop_threshold is parsed from config file."""
+        conf = tmp_path / "statusline.conf"
+        conf.write_text("compaction_drop_threshold=0.4\n")
+        config = Config.load(conf)
+        assert config.compaction_drop_threshold == pytest.approx(0.4, abs=1e-6)
+
+    def test_parse_valid_mi_warn_threshold(self, tmp_path):
+        """Valid compact_mi_warn_threshold is parsed from config file."""
+        conf = tmp_path / "statusline.conf"
+        conf.write_text("compact_mi_warn_threshold=0.7\n")
+        config = Config.load(conf)
+        assert config.compact_mi_warn_threshold == pytest.approx(0.7, abs=1e-6)
+
+    def test_invalid_drop_threshold_uses_default(self, tmp_path):
+        """Invalid (out-of-range) compaction_drop_threshold falls back to default."""
+        conf = tmp_path / "statusline.conf"
+        conf.write_text("compaction_drop_threshold=1.5\n")
+        config = Config.load(conf)
+        assert config.compaction_drop_threshold == 0.5  # default unchanged
+
+    def test_non_numeric_drop_threshold_uses_default(self, tmp_path):
+        """Non-numeric compaction_drop_threshold falls back to default."""
+        conf = tmp_path / "statusline.conf"
+        conf.write_text("compaction_drop_threshold=banana\n")
+        config = Config.load(conf)
+        assert config.compaction_drop_threshold == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Class 5: render_timeseries with compaction markers (smoke tests)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTimeseriesCompaction:
+    """Smoke tests for compaction marker overlay in render_timeseries."""
+
+    def _make_renderer(self) -> GraphRenderer:
+        return GraphRenderer(
+            colors=ColorManager(enabled=False),
+            dimensions=GraphDimensions(
+                term_width=80,
+                term_height=30,
+                graph_width=60,
+                graph_height=10,
+            ),
+        )
+
+    def test_no_markers_does_not_error(self):
+        """Calling render_timeseries without compaction_indices works normally."""
+        renderer = self._make_renderer()
+        renderer.begin_buffering()
+        renderer.render_timeseries(
+            [10_000, 20_000, 30_000],
+            [1000, 2000, 3000],
+            "Test Graph",
+            "",
+        )
+        output = renderer.get_buffer()
+        assert "Test Graph" in output
+
+    def test_markers_included_in_output(self):
+        """When compaction_indices are given, ▼ marker appears in output."""
+        renderer = self._make_renderer()
+        renderer.begin_buffering()
+        # Values: grows then compacts at index 2
+        renderer.render_timeseries(
+            [10_000, 20_000, 5_000, 8_000],
+            [1000, 2000, 3000, 4000],
+            "Test Graph",
+            "",
+            compaction_indices=[2],
+        )
+        output = renderer.get_buffer()
+        assert "▼" in output
+
+    def test_no_markers_when_indices_empty(self):
+        """Empty compaction_indices list produces no markers."""
+        renderer = self._make_renderer()
+        renderer.begin_buffering()
+        renderer.render_timeseries(
+            [10_000, 20_000, 30_000],
+            [1000, 2000, 3000],
+            "Test Graph",
+            "",
+            compaction_indices=[],
+        )
+        output = renderer.get_buffer()
+        assert "▼" not in output
+
+    def test_out_of_bounds_index_no_crash(self):
+        """Out-of-bounds compaction index is silently ignored."""
+        renderer = self._make_renderer()
+        renderer.begin_buffering()
+        renderer.render_timeseries(
+            [10_000, 20_000],
+            [1000, 2000],
+            "Test Graph",
+            "",
+            compaction_indices=[99],  # way out of bounds
+        )
+        output = renderer.get_buffer()
+        assert "Test Graph" in output

--- a/tests/python/test_compaction.py
+++ b/tests/python/test_compaction.py
@@ -11,7 +11,6 @@ from claude_statusline.graphs.intelligence import calculate_intelligence
 from claude_statusline.graphs.renderer import GraphDimensions, GraphRenderer
 from claude_statusline.graphs.statistics import detect_compaction_events
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -116,11 +115,11 @@ class TestDetectCompactionEvents:
     def test_multiple_compactions(self):
         """Multiple compaction events in a session are all detected."""
         values = [
-            100_000,   # index 0: baseline
-            120_000,   # index 1: growth
-            40_000,    # index 2: first compaction (40k < 120k * 0.5 = 60k)
-            60_000,    # index 3: growth
-            10_000,    # index 4: second compaction (10k < 60k * 0.5 = 30k)
+            100_000,  # index 0: baseline
+            120_000,  # index 1: growth
+            40_000,  # index 2: first compaction (40k < 120k * 0.5 = 60k)
+            60_000,  # index 3: growth
+            10_000,  # index 4: second compaction (10k < 60k * 0.5 = 30k)
         ]
         events = detect_compaction_events(values)
         assert 2 in events

--- a/tests/python/test_intelligence.py
+++ b/tests/python/test_intelligence.py
@@ -9,6 +9,7 @@ import pytest
 
 from claude_statusline.core.state import StateEntry
 from claude_statusline.graphs.intelligence import (
+    _ZONE_RECOMMENDATIONS,
     MI_GREEN_THRESHOLD,
     MI_YELLOW_THRESHOLD,
     MODEL_PROFILES,
@@ -16,7 +17,6 @@ from claude_statusline.graphs.intelligence import (
     ZONE_1M_D_MAX,
     ZONE_1M_P_MAX,
     ZONE_1M_X_MAX,
-    _ZONE_RECOMMENDATIONS,
     calculate_context_pressure,
     calculate_intelligence,
     format_mi_score,

--- a/tests/python/test_report.py
+++ b/tests/python/test_report.py
@@ -2,13 +2,17 @@
 
 from datetime import datetime, timedelta
 
-import pytest
-
-from claude_statusline.analytics import ProjectStats, SessionStats, load_all_projects, _group_sessions_by_project
+from claude_statusline.analytics import (
+    ProjectStats,
+    SessionStats,
+    _group_sessions_by_project,
+)
 from claude_statusline.cli.report import generate_report
 
 
-def _make_session(session_id, start_offset_days=0, end_offset_days=0, project_dir="/home/user/proj"):
+def _make_session(
+    session_id, start_offset_days=0, end_offset_days=0, project_dir="/home/user/proj"
+):
     """Return a SessionStats with start/end times relative to now."""
     now = int(datetime.now().timestamp())
     start = now - int(start_offset_days * 86400)
@@ -108,7 +112,7 @@ def test_report_period_without_since_days():
         total_cache_read=0,
         cost_usd=0.01,
         start_time=1700000000,  # 2023-11-14
-        end_time=1700100000,    # ~1 day later
+        end_time=1700100000,  # ~1 day later
         entry_count=1,
     )
     project = ProjectStats(


### PR DESCRIPTION
## Summary

- **#62**: Detects compaction events (>50 % context drop between consecutive CSV entries) and annotates the cumulative graph with a `▼` marker (orange) at each event position
- **#65**: At each detected compaction, computes the MI score and shows a warning (`⚠`) if MI was below threshold (default 0.6 → lossy summary likely) or a confirmation (`✓`) if MI was healthy
- Both thresholds are configurable via `~/.claude/statusline.conf` (`compaction_drop_threshold` and `compact_mi_warn_threshold`)
- `scripts/statusline.py` fully synced per CLAUDE.md requirements

## Changes

| File | What changed |
|---|---|
| `graphs/statistics.py` | New `detect_compaction_events()` function |
| `graphs/renderer.py` | `render_timeseries` accepts `compaction_indices`; `render_summary` accepts `compaction_events` + threshold |
| `core/config.py` | Two new config fields + parsing |
| `cli/context_stats.py` | Wires detection and MI-at-compact into `render_once` |
| `scripts/statusline.py` | Synced constants, function, and config parsing |
| `tests/python/test_compaction.py` | 36 new tests (new file) |

## Test plan

- [x] `pytest tests/python/ -v` — 402 passed, 0 failed
- [x] `detect_compaction_events` edge cases: empty list, single value, exact 50% boundary, multiple events, custom thresholds
- [x] MI quality: low MI entry classified as warning, healthy MI as confirmation, threshold boundary
- [x] `render_summary` output: no output when no compactions, count line, per-event warning/confirmation, custom threshold
- [x] `render_timeseries`: `▼` marker in output when compaction indices given, absent when empty, no crash on out-of-bounds index
- [x] Config parsing: default values, valid/invalid values for both new keys

Closes #62
Closes #65