### PR TITLE
feat(cli): default to latest session and add sessions command (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ graph TD
     C --> E["context-stats graph"]
     C --> F["context-stats export"]
     C --> G["context-stats report"]
+    C --> H["context-stats sessions"]
 
     subgraph L1["Level 1 — Live"]
         D
         E
+        H
     end
 
     subgraph L2["Level 2 — Session"]
@@ -43,7 +45,7 @@ graph TD
 
 | Level | Tool | What you learn |
 |---|---|---|
-| **Live** | Status line + graph dashboard | Context zone, MI score, token delta — act now, not after it's too late |
+| **Live** | Status line + graph dashboard + sessions list | Context zone, MI score, token delta — act now, not after it's too late |
 | **Session** | `context-stats export` | Cache efficiency, interaction timeline, zone history for one session |
 | **Report** | `context-stats report` | Cost breakdown, cache analysis, cross-project patterns across weeks or months |
 
@@ -106,11 +108,23 @@ MI(u) = max(0, 1 - u^β)
 
 Color-coded: **green** (>0.70), **yellow** (0.40–0.70), **red** (<0.40 — start a new session). Override with `mi_curve_beta=1.5` in config.
 
+### Session Listing
+
+Find and switch between active sessions:
+
+```bash
+context-stats sessions                  # Sessions from the last 5 minutes
+context-stats sessions --minutes 30     # Widen the search window
+```
+
+Each session shows the project name, model, token count, and how recently it was active.
+
 ### Live Graph Dashboard
 
 ```bash
-context-stats <session_id> graph               # Context growth per interaction
-context-stats <session_id> graph --type all    # All graphs
+context-stats graph                     # Context growth for the latest session
+context-stats graph --type all          # All graphs
+context-stats <session_id> graph        # Specific session
 ```
 
 | Graph | What it answers |
@@ -138,7 +152,8 @@ Auto-refreshes every 2 seconds. Pass `-w 5` to slow down or `--no-watch` to show
 Export a full deep-dive when you need to understand what happened in a specific session:
 
 ```bash
-context-stats <session_id> export --output report.md
+context-stats export --output report.md              # Latest session
+context-stats <session_id> export --output report.md  # Specific session
 ```
 
 | Section | What you learn |
@@ -169,11 +184,12 @@ See the full example in [`context-stats-export-output.md`](context-stats-export-
 Claude's prompt cache has a ~5 minute TTL. Keep it alive during pauses to avoid expensive cache misses:
 
 ```bash
-context-stats <session_id> cache-warm on 30m
+context-stats cache-warm on 30m              # Latest session
+context-stats <session_id> cache-warm on 30m  # Specific session
 ```
 
 ```bash
-context-stats <session_id> cache-warm off
+context-stats cache-warm off
 ```
 
 Heartbeats fire every 4 minutes. Runs as a detached background process.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1226,6 +1226,14 @@
             <svg class="check green" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/></svg>
             MI quality flag at compaction — warns if summary was created at low intelligence
           </li>
+          <li>
+            <svg class="check green" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/></svg>
+            Session listing — <code>context-stats sessions</code> shows recent sessions with metadata
+          </li>
+          <li>
+            <svg class="check green" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/></svg>
+            Auto-detect latest session — no session ID needed for any command
+          </li>
         </ul>
       </div>
 
@@ -1361,8 +1369,8 @@
             <span class="terminal-title">cache-warm — keep the 5-min TTL alive</span>
           </div>
           <div class="terminal-body">
-<div class="t-muted"># Activate keep-warm for the current session</div>
-<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats &lt;session_id&gt; cache-warm on</span></div>
+<div class="t-muted"># Activate keep-warm for the latest session (no ID needed)</div>
+<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats cache-warm on</span></div>
 <div class="t-green">  Cache keep-warm started</div>
 <div><span class="t-key">  Session:  </span><span class="t-cyan">abc-1234</span></div>
 <div><span class="t-key">  Interval: </span><span class="t-cyan">every 4 min</span></div>
@@ -1370,11 +1378,11 @@
 <div><span class="t-key">  PID:      </span><span class="t-indigo">12845</span></div>
 <br/>
 <div class="t-muted"># Use a custom duration</div>
-<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats &lt;session_id&gt; cache-warm on 1h</span></div>
+<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats cache-warm on 1h</span></div>
 <div class="t-green">  Cache keep-warm started <span class="t-muted">(1h)</span></div>
 <br/>
 <div class="t-muted"># Stop the heartbeat early</div>
-<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats &lt;session_id&gt; cache-warm off</span></div>
+<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats cache-warm off</span></div>
 <div class="t-green">  Cache keep-warm stopped</div>
 <br/>
 <div class="t-muted"># Verify savings in your session report</div>
@@ -1393,10 +1401,11 @@
   <div class="container">
     <span class="section-label">Real Output</span>
     <h2>What you actually see<br/>in the terminal.</h2>
-    <p class="lead">Three commands — each level of analytics, shown in full.</p>
+    <p class="lead">Four commands — each level of analytics, shown in full.</p>
 
     <div class="examples-tabs">
       <button class="tab-btn active green" onclick="switchTab(event,'tab-graph')">context-stats graph</button>
+      <button class="tab-btn" onclick="switchTab(event,'tab-sessions')">context-stats sessions</button>
       <button class="tab-btn" onclick="switchTab(event,'tab-export')">context-stats export</button>
       <button class="tab-btn" onclick="switchTab(event,'tab-report')">context-stats report</button>
     </div>
@@ -1452,6 +1461,40 @@
 <div class="t-muted">   3│ <span class="t-cyan">░░░░░░░░▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓</span></div>
 <div class="t-muted">   2│ <span class="t-cyan">░░░░░░░░░░░░▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓</span></div>
 <div class="t-muted">   1│ <span class="t-cyan">░░░░░░░░░░░░░░░░▓▓▓▓▓▓▓▓▓▓▓▓</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sessions tab -->
+    <div id="tab-sessions" class="tab-panel">
+      <div class="example-terminal">
+        <div class="example-terminal-body">
+<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats sessions</span></div>
+<br/>
+<div class="t-h1">  Recent Sessions <span class="t-muted">(last 5 min)</span></div>
+<br/>
+<div>  <span class="t-cyan">43b5ed93-e7a3-44d9-9d58-bd35911f17e9</span></div>
+<div>    <span class="t-green">my-project</span> <span class="t-muted">·</span> <span class="t-muted">claude-opus-4-6[1m]</span> <span class="t-muted">·</span> 59K tokens <span class="t-muted">· 1m 55s ago</span></div>
+<br/>
+<div>  <span class="t-cyan">66c00dcb-ebf6-4ed0-872e-23a60d715d60</span></div>
+<div>    <span class="t-green">api-server</span> <span class="t-muted">·</span> <span class="t-muted">claude-opus-4-6[1m]</span> <span class="t-muted">·</span> 83K tokens <span class="t-muted">· 4m 52s ago</span></div>
+<br/>
+<div class="t-muted">  Tip: context-stats 43b5ed93-e7a3-44d9-9d58-bd35911f17e9 graph</div>
+<br/>
+<div><span class="t-prompt">$ </span><span class="t-cmd">context-stats sessions --minutes 30</span></div>
+<br/>
+<div class="t-h1">  Recent Sessions <span class="t-muted">(last 30 min)</span></div>
+<br/>
+<div>  <span class="t-cyan">43b5ed93-e7a3-44d9-9d58-bd35911f17e9</span></div>
+<div>    <span class="t-green">my-project</span> <span class="t-muted">·</span> <span class="t-muted">claude-opus-4-6[1m]</span> <span class="t-muted">·</span> 59K tokens <span class="t-muted">· 1m 55s ago</span></div>
+<br/>
+<div>  <span class="t-cyan">66c00dcb-ebf6-4ed0-872e-23a60d715d60</span></div>
+<div>    <span class="t-green">api-server</span> <span class="t-muted">·</span> <span class="t-muted">claude-opus-4-6[1m]</span> <span class="t-muted">·</span> 83K tokens <span class="t-muted">· 4m 52s ago</span></div>
+<br/>
+<div>  <span class="t-cyan">a1b2c3d4-e5f6-7890-abcd-ef1234567890</span></div>
+<div>    <span class="t-green">docs-site</span> <span class="t-muted">·</span> <span class="t-muted">claude-sonnet-4-6</span> <span class="t-muted">·</span> 142K tokens <span class="t-muted">· 18m ago</span></div>
+<br/>
+<div class="t-muted">  Tip: context-stats 43b5ed93-e7a3-44d9-9d58-bd35911f17e9 graph</div>
         </div>
       </div>
     </div>
@@ -1582,6 +1625,7 @@ function switchTab(e, panelId) {
   section.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
   e.target.classList.add('active');
   if (panelId === 'tab-graph') { e.target.classList.add('green'); }
+  else if (panelId === 'tab-sessions') { e.target.style.color = 'var(--cyan)'; e.target.style.borderBottomColor = 'var(--cyan)'; }
   else if (panelId === 'tab-report') { e.target.style.color = 'var(--indigo)'; e.target.style.borderBottomColor = 'var(--indigo)'; }
   document.getElementById(panelId).classList.add('active');
 }
@@ -1799,11 +1843,15 @@ function switchTab(e, panelId) {
           <code style="white-space:pre;"># Live ASCII dashboard — context, MI, cache, delta
 context-stats graph
 
+# List recent sessions (last 5 min by default)
+context-stats sessions
+context-stats sessions --minutes 30
+
 # Keep the prompt cache alive during idle gaps
-context-stats &lt;session_id&gt; cache-warm on
+context-stats cache-warm on
 
 # Export full session report to Markdown
-context-stats export &lt;session_id&gt;
+context-stats export
 
 # Multi-project analytics (last 30 days)
 context-stats report --since-days 30

--- a/scripts/e2e-install-test.sh
+++ b/scripts/e2e-install-test.sh
@@ -70,6 +70,23 @@ assert_exits_ok() {
     fi
 }
 
+# Run a command, assert exit 0, and check output contains a substring.
+# Usage: assert_output_contains "label" "substring" cmd [args...]
+assert_output_contains() {
+    local label="$1"
+    local needle="$2"
+    shift 2
+    local output exit_code
+    output=$("$@" 2>&1) && exit_code=$? || exit_code=$?
+    if [ "$exit_code" -ne 0 ]; then
+        fail "$label (exit=$exit_code)"
+    elif echo "$output" | grep -qF "$needle"; then
+        pass "$label"
+    else
+        fail "$label (output missing '$needle': '${output:0:120}')"
+    fi
+}
+
 # Pipe JSON through a command and assert exit 0 with non-empty output.
 # Usage: assert_statusline_ok "label" cmd [args...]
 assert_statusline_ok() {
@@ -158,6 +175,56 @@ run_python_e2e() {
     else
         info "scripts/statusline.py not found — skipping standalone script test"
     fi
+
+    # ── Session commands E2E ──────────────────────────────────────────────────
+    section "Python — Session Commands"
+
+    # Assert: context-stats sessions exits 0 when no state files exist
+    assert_exits_ok "context-stats sessions exits 0 (no data)" "$venv_bin/context-stats" sessions
+
+    # Assert: context-stats sessions --minutes flag is accepted
+    assert_exits_ok "context-stats sessions --minutes 30" "$venv_bin/context-stats" sessions --minutes 30
+
+    # Assert: context-stats with no args + --no-watch exits 0 (defaults to latest session graph)
+    assert_exits_ok "context-stats --no-watch exits 0 (no data)" "$venv_bin/context-stats" graph --no-watch
+
+    # Create a fake state file to test sessions listing with real data
+    local state_dir="$HOME/.claude/statusline"
+    local fake_session_id="e2e-smoke-test-$$"
+    local fake_state_file="$state_dir/statusline.${fake_session_id}.state"
+    mkdir -p "$state_dir"
+    local ts
+    ts=$(date +%s)
+    local ts_prev=$((ts - 10))
+    # Write 2 entries (graph needs at least 2 data points)
+    echo "${ts_prev},2000,1000,200,100,500,400,0.02,10,5,${fake_session_id},claude-sonnet-4-20250514,/tmp/e2e-project,200000" > "$fake_state_file"
+    echo "${ts},5000,2000,500,200,1000,800,0.05,20,10,${fake_session_id},claude-sonnet-4-20250514,/tmp/e2e-project,200000" >> "$fake_state_file"
+
+    # Assert: sessions command lists the fake session
+    assert_output_contains \
+        "context-stats sessions lists fake session" \
+        "$fake_session_id" \
+        "$venv_bin/context-stats" sessions --minutes 5
+
+    # Assert: sessions output includes project name from state file
+    assert_output_contains \
+        "context-stats sessions shows project name" \
+        "e2e-project" \
+        "$venv_bin/context-stats" sessions --minutes 5
+
+    # Assert: sessions output includes model name
+    assert_output_contains \
+        "context-stats sessions shows model" \
+        "claude-sonnet-4-20250514" \
+        "$venv_bin/context-stats" sessions --minutes 5
+
+    # Assert: graph --no-watch picks up latest session automatically
+    assert_cmd_ok \
+        "context-stats graph --no-watch auto-detects latest session" \
+        "$venv_bin/context-stats" graph --no-watch
+
+    # Clean up fake state file
+    rm -f "$fake_state_file"
 
     rm -rf "$venv_dir"
 }

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -165,7 +165,7 @@ DATA SOURCE:
 _KNOWN_ACTIONS = {"graph", "export", "explain", "cache-warm", "report", "sessions"}
 
 
-def _normalize_argv(argv: list[str]) -> tuple[str, str, list[str]]:
+def _normalize_argv(argv: list[str]) -> tuple[str, str | None, list[str]]:
     """Determine action, session_id, and remaining args from raw argv.
 
     Supported patterns:

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -699,7 +699,7 @@ def run_sessions(minutes: int, colors: ColorManager) -> None:
         f"{colors.dim}(last {minutes} min){colors.reset}\n"
     )
 
-    for mtime, session_id, file_path in sessions:
+    for mtime, session_id, _file_path in sessions:
         # Read last entry for metadata
         sf = StateFile(session_id)
         last_entry = sf.read_last_entry()
@@ -816,9 +816,7 @@ def main() -> None:
                 try:
                     minutes = int(remaining[i + 1])
                 except ValueError:
-                    sys.stderr.write(
-                        f"Error: Invalid value for --minutes: '{remaining[i + 1]}'\n"
-                    )
+                    sys.stderr.write(f"Error: Invalid value for --minutes: '{remaining[i + 1]}'\n")
                     sys.exit(1)
                 i += 2
             else:

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -4,11 +4,15 @@
 Displays ASCII graphs of token consumption over time.
 
 Usage:
-    context-stats <session_id> <action> [parameters]
+    context-stats [session_id] [action] [parameters]
+
+When session_id is omitted, the most recent session is used automatically.
+When action is omitted, defaults to 'graph'.
 
 Actions:
     graph       Live ASCII graphs of context usage (default)
     export      Export session stats as a markdown report
+    sessions    List recent sessions
     explain     Diagnostic dump of Claude Code's JSON context (pipe JSON to stdin)
     cache-warm  Keep session prompt cache alive via a background heartbeat
 
@@ -51,18 +55,25 @@ def show_help() -> None:
         """Context Stats Visualizer for Claude Code
 
 USAGE:
-    context-stats <session_id> <action> [parameters]
+    context-stats [session_id] [action] [parameters]
+
+    When session_id is omitted, the most recent session is used automatically.
+    When action is omitted, defaults to 'graph'.
 
 ARGUMENTS:
-    session_id    Required. The session ID to operate on.
-    action        Required. The action to perform.
+    session_id    Optional. The session ID to operate on (default: latest).
+    action        Optional. The action to perform (default: graph).
 
 ACTIONS:
     graph         Show live ASCII graphs of context usage
     export        Export session stats as a markdown report
+    sessions      List recent sessions (default: last 5 minutes)
     explain       Diagnostic dump of Claude Code's JSON context (pipe JSON to stdin)
     cache-warm    Keep session prompt cache alive via a background heartbeat
     report        Generate comprehensive token usage analytics across all projects
+
+SESSIONS OPTIONS:
+    --minutes N    Show sessions from the last N minutes (default: 5)
 
 CACHE-WARM OPTIONS:
     on [duration]  Start heartbeat for the given duration (e.g. 30m, 1h). Default: 30m
@@ -93,8 +104,20 @@ NOTE:
     Press Ctrl+C to exit. Use --no-watch to display graphs once and exit.
 
 EXAMPLES:
-    # Show live graphs (refreshes every 2s)
+    # Show live graphs for the latest session (no session ID needed)
+    context-stats graph
+
+    # Show live graphs for a specific session
     context-stats abc123def graph
+
+    # Shorthand: just run with no arguments for latest session graphs
+    context-stats
+
+    # List recent sessions (last 5 minutes)
+    context-stats sessions
+
+    # List sessions from the last 30 minutes
+    context-stats sessions --minutes 30
 
     # Show graphs once and exit
     context-stats abc123def graph --no-watch
@@ -107,6 +130,9 @@ EXAMPLES:
 
     # Export session stats as markdown
     context-stats abc123def export --output report.md
+
+    # Export latest session stats
+    context-stats export
 
     # Diagnostic dump (pipe Claude Code JSON context)
     echo '{"model":{"display_name":"Opus"},...}' | context-stats explain
@@ -136,48 +162,57 @@ DATA SOURCE:
 
 
 # Known action names — used to distinguish actions from session IDs in argv
-_KNOWN_ACTIONS = {"graph", "export", "explain", "cache-warm", "report"}
+_KNOWN_ACTIONS = {"graph", "export", "explain", "cache-warm", "report", "sessions"}
 
 
 def _normalize_argv(argv: list[str]) -> tuple[str, str, list[str]]:
     """Determine action, session_id, and remaining args from raw argv.
 
-    Requires the explicit pattern:
-      context-stats <session_id> <action> [parameters]
+    Supported patterns:
+      context-stats                           → graph, latest session
+      context-stats <action> [parameters]     → action, latest session
+      context-stats <session_id>              → graph, specific session
+      context-stats <session_id> <action>     → action, specific session
 
-    Special cases: explain and report can be called as 'context-stats <action>' (without session_id).
-    When session_id is missing and action is 'explain' or 'report', uses '-' as placeholder.
+    Session_id is None when omitted (auto-detect latest).
+    Explain uses '-' as a placeholder session_id.
 
     Args:
         argv: sys.argv[1:] (arguments after the program name).
 
     Returns:
-        Tuple of (action, session_id, remaining_args).
+        Tuple of (action, session_id | None, remaining_args).
 
     Raises:
-        SystemExit: If session_id or action are missing (except for explain/report).
+        SystemExit: If an unknown action is specified.
     """
     # Strip out global flags so they don't interfere with positional detection
     positionals = [a for a in argv if not a.startswith("-")]
 
     if not positionals:
-        sys.stderr.write("Error: Missing required arguments.\n\n")
-        show_help()
-        sys.exit(1)
+        # No arguments at all: default to graph with latest session
+        remaining = [a for a in argv if a.startswith("-")]
+        return "graph", None, remaining
 
-    # Special case: explain and report can be called with just the action (no session_id)
-    if positionals[0] in {"explain", "report"}:
+    # First positional is a known action: no session_id provided
+    if positionals[0] in _KNOWN_ACTIONS:
+        action = positionals[0]
         remaining = list(argv)
-        remaining.remove(positionals[0])
-        return positionals[0], "-", remaining
+        remaining.remove(action)
+        # explain historically used "-" placeholder; keep for explain
+        if action == "explain":
+            return action, "-", remaining
+        return action, None, remaining
 
-    # Standard case: <session_id> <action> [parameters]
-    if len(positionals) < 2:
-        sys.stderr.write("Error: Missing required arguments.\n\n")
-        show_help()
-        sys.exit(1)
-
+    # First positional is not a known action: treat as session_id
     session_id = positionals[0]
+
+    if len(positionals) < 2:
+        # Single positional that is not a known action: treat as session_id, default to graph
+        remaining = list(argv)
+        remaining.remove(session_id)
+        return "graph", session_id, remaining
+
     action = positionals[1]
 
     if action not in _KNOWN_ACTIONS:
@@ -252,8 +287,8 @@ def parse_args() -> argparse.Namespace:
     # Parse required session_id and action
     action, session_id, remaining = _normalize_argv(raw_argv)
 
-    # Validate session_id format (skip for "-" placeholder used by explain)
-    if session_id != "-":
+    # Validate session_id format (skip for "-" placeholder and None/auto-detect)
+    if session_id is not None and session_id != "-":
         try:
             _validate_session_id(session_id)
         except ValueError as e:
@@ -261,8 +296,8 @@ def parse_args() -> argparse.Namespace:
             sys.exit(1)
 
     if action == "graph":
-        # Inject session_id into remaining for graph parser
-        remaining = [session_id] + remaining
+        # Inject session_id into remaining for graph parser (skip if None/auto-detect)
+        remaining = ([session_id] if session_id is not None else []) + remaining
         parser = _build_graph_parser()
         args = parser.parse_args(remaining)
         if args.help:
@@ -627,6 +662,89 @@ def show_waiting_message(
     print(_format_waiting_message(colors, session_id, message))
 
 
+def run_sessions(minutes: int, colors: ColorManager) -> None:
+    """List recent sessions within the given time window.
+
+    Args:
+        minutes: Show sessions active within the last N minutes
+        colors: ColorManager instance
+    """
+    state_file = StateFile(None)
+    cutoff = time.time() - (minutes * 60)
+
+    sessions: list[tuple[float, str, Path]] = []
+    for file_path in state_file.STATE_DIR.glob("statusline.*.state"):
+        try:
+            mtime = file_path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime >= cutoff:
+            name = file_path.stem
+            if name.startswith("statusline."):
+                session_id = name[11:]
+                if session_id:
+                    sessions.append((mtime, session_id, file_path))
+
+    # Sort by most recent first
+    sessions.sort(key=lambda x: x[0], reverse=True)
+
+    if not sessions:
+        print(f"{colors.yellow}No sessions found in the last {minutes} minute(s).{colors.reset}")
+        print(f"{colors.dim}Tip: Use --minutes N to widen the search window.{colors.reset}")
+        return
+
+    now = time.time()
+    print(
+        f"\n{colors.bold}{colors.magenta}Recent Sessions{colors.reset} "
+        f"{colors.dim}(last {minutes} min){colors.reset}\n"
+    )
+
+    for mtime, session_id, file_path in sessions:
+        # Read last entry for metadata
+        sf = StateFile(session_id)
+        last_entry = sf.read_last_entry()
+
+        # Format time ago
+        ago = now - mtime
+        if ago < 60:
+            ago_str = f"{int(ago)}s ago"
+        else:
+            mins = int(ago // 60)
+            secs = int(ago % 60)
+            ago_str = f"{mins}m {secs}s ago" if secs else f"{mins}m ago"
+
+        # Extract metadata
+        project = ""
+        model = ""
+        tokens = ""
+        if last_entry:
+            if last_entry.workspace_project_dir:
+                project = Path(last_entry.workspace_project_dir).name
+            model = last_entry.model_id or ""
+            total = last_entry.current_used_tokens
+            if total >= 1_000_000:
+                tokens = f"{total / 1_000_000:.1f}M tokens"
+            elif total >= 1_000:
+                tokens = f"{total / 1_000:.0f}K tokens"
+            else:
+                tokens = f"{total} tokens"
+
+        # Display
+        print(f"  {colors.cyan}{session_id}{colors.reset}")
+        details = []
+        if project:
+            details.append(f"{colors.green}{project}{colors.reset}")
+        if model:
+            details.append(f"{colors.dim}{model}{colors.reset}")
+        if tokens:
+            details.append(tokens)
+        details.append(f"{colors.dim}{ago_str}{colors.reset}")
+        print(f"    {' · '.join(details)}")
+        print()
+
+    print(f"{colors.dim}Tip: context-stats {sessions[0][1]} graph{colors.reset}")
+
+
 def _ensure_utf8_stdout() -> None:
     """Reconfigure stdout/stderr to UTF-8 on Windows where cp1252 is the default."""
     if sys.stdout.encoding and sys.stdout.encoding.lower().replace("-", "") != "utf8":
@@ -670,9 +788,42 @@ def main() -> None:
     if args.action == "cache-warm":
         from claude_statusline.cli.cache_warm import run_cache_warm
 
+        session_id = args.session_id
+        if session_id is None:
+            # Resolve latest session for cache-warm (requires a real session_id)
+            sf = StateFile(None)
+            latest = sf.find_latest_state_file()
+            if latest:
+                session_id = latest.stem.replace("statusline.", "")
+            else:
+                sys.stderr.write("Error: No session data found. Cannot start cache-warm.\n")
+                sys.exit(1)
+
         color_enabled = "--no-color" not in sys.argv and sys.stdout.isatty()
         colors = ColorManager(enabled=color_enabled)
-        run_cache_warm(args.session_id, args.remaining, colors)
+        run_cache_warm(session_id, args.remaining, colors)
+        return
+
+    if args.action == "sessions":
+        color_enabled = "--no-color" not in sys.argv and sys.stdout.isatty()
+        colors = ColorManager(enabled=color_enabled)
+        # Parse --minutes flag from remaining args
+        minutes = 5
+        remaining = args.remaining if hasattr(args, "remaining") else []
+        i = 0
+        while i < len(remaining):
+            if remaining[i] == "--minutes" and i + 1 < len(remaining):
+                try:
+                    minutes = int(remaining[i + 1])
+                except ValueError:
+                    sys.stderr.write(
+                        f"Error: Invalid value for --minutes: '{remaining[i + 1]}'\n"
+                    )
+                    sys.exit(1)
+                i += 2
+            else:
+                i += 1
+        run_sessions(minutes, colors)
         return
 
     if args.action == "report":

--- a/tests/python/test_sessions.py
+++ b/tests/python/test_sessions.py
@@ -1,0 +1,203 @@
+"""Tests for session-id auto-detection and sessions listing."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_statusline.cli.context_stats import _normalize_argv, run_sessions
+from claude_statusline.core.colors import ColorManager
+from claude_statusline.core.state import StateEntry, StateFile
+
+
+class TestNormalizeArgv:
+    """Test _normalize_argv with optional session_id."""
+
+    def test_no_args_defaults_to_graph_none(self):
+        action, session_id, remaining = _normalize_argv([])
+        assert action == "graph"
+        assert session_id is None
+
+    def test_action_only_graph(self):
+        action, session_id, remaining = _normalize_argv(["graph"])
+        assert action == "graph"
+        assert session_id is None
+
+    def test_action_only_export(self):
+        action, session_id, remaining = _normalize_argv(["export"])
+        assert action == "export"
+        assert session_id is None
+
+    def test_action_only_sessions(self):
+        action, session_id, remaining = _normalize_argv(["sessions"])
+        assert action == "sessions"
+        assert session_id is None
+
+    def test_action_only_report(self):
+        action, session_id, remaining = _normalize_argv(["report"])
+        assert action == "report"
+        assert session_id is None
+
+    def test_action_only_explain(self):
+        action, session_id, remaining = _normalize_argv(["explain"])
+        assert action == "explain"
+        assert session_id == "-"
+
+    def test_session_id_and_action(self):
+        action, session_id, remaining = _normalize_argv(["abc123", "graph"])
+        assert action == "graph"
+        assert session_id == "abc123"
+
+    def test_session_id_only_defaults_to_graph(self):
+        action, session_id, remaining = _normalize_argv(["abc123"])
+        assert action == "graph"
+        assert session_id == "abc123"
+
+    def test_flags_passed_through(self):
+        action, session_id, remaining = _normalize_argv(["graph", "--no-watch", "--type", "mi"])
+        assert action == "graph"
+        assert session_id is None
+        assert "--no-watch" in remaining
+        assert "--type" in remaining
+        assert "mi" in remaining
+
+    def test_session_and_flags(self):
+        action, session_id, remaining = _normalize_argv(
+            ["abc123", "graph", "--no-watch"]
+        )
+        assert action == "graph"
+        assert session_id == "abc123"
+        assert "--no-watch" in remaining
+
+    def test_no_args_with_flags(self):
+        action, session_id, remaining = _normalize_argv(["--no-color"])
+        assert action == "graph"
+        assert session_id is None
+        assert "--no-color" in remaining
+
+    def test_sessions_with_minutes(self):
+        action, session_id, remaining = _normalize_argv(
+            ["sessions", "--minutes", "30"]
+        )
+        assert action == "sessions"
+        assert session_id is None
+        assert "--minutes" in remaining
+        assert "30" in remaining
+
+    def test_unknown_action_with_session_id(self):
+        with pytest.raises(SystemExit):
+            _normalize_argv(["abc123", "unknown-action"])
+
+    def test_cache_warm_without_session(self):
+        action, session_id, remaining = _normalize_argv(["cache-warm"])
+        assert action == "cache-warm"
+        assert session_id is None
+
+
+class TestRunSessions:
+    """Test run_sessions listing."""
+
+    def test_no_sessions_found(self, tmp_path):
+        colors = ColorManager(enabled=False)
+        with patch.object(StateFile, "STATE_DIR", tmp_path):
+            run_sessions(5, colors)
+
+    def test_lists_recent_sessions(self, tmp_path):
+        colors = ColorManager(enabled=False)
+
+        # Create fake state files
+        entry = StateEntry(
+            timestamp=int(time.time()),
+            total_input_tokens=1000,
+            total_output_tokens=500,
+            current_input_tokens=100,
+            current_output_tokens=50,
+            cache_creation=200,
+            cache_read=300,
+            cost_usd=0.01,
+            lines_added=10,
+            lines_removed=5,
+            session_id="test-session-1",
+            model_id="claude-opus-4-6",
+            workspace_project_dir="/home/user/project",
+            context_window_size=200000,
+        )
+
+        state_file = tmp_path / "statusline.test-session-1.state"
+        state_file.write_text(entry.to_csv_line() + "\n")
+
+        with patch.object(StateFile, "STATE_DIR", tmp_path):
+            run_sessions(5, colors)
+
+    def test_filters_old_sessions(self, tmp_path):
+        colors = ColorManager(enabled=False)
+
+        # Create a state file and set its mtime to 10 minutes ago
+        entry = StateEntry(
+            timestamp=int(time.time()) - 600,
+            total_input_tokens=1000,
+            total_output_tokens=500,
+            current_input_tokens=100,
+            current_output_tokens=50,
+            cache_creation=200,
+            cache_read=300,
+            cost_usd=0.01,
+            lines_added=10,
+            lines_removed=5,
+            session_id="old-session",
+            model_id="claude-opus-4-6",
+            workspace_project_dir="/home/user/project",
+            context_window_size=200000,
+        )
+
+        state_file = tmp_path / "statusline.old-session.state"
+        state_file.write_text(entry.to_csv_line() + "\n")
+
+        import os
+
+        old_time = time.time() - 600
+        os.utime(state_file, (old_time, old_time))
+
+        with patch.object(StateFile, "STATE_DIR", tmp_path):
+            # With 5-minute window, the 10-minute-old session should not appear
+            run_sessions(5, colors)
+
+    def test_sorts_by_most_recent(self, tmp_path, capsys):
+        colors = ColorManager(enabled=False)
+
+        now = time.time()
+        for i, sid in enumerate(["session-a", "session-b", "session-c"]):
+            entry = StateEntry(
+                timestamp=int(now),
+                total_input_tokens=1000,
+                total_output_tokens=500,
+                current_input_tokens=100,
+                current_output_tokens=50,
+                cache_creation=200,
+                cache_read=300,
+                cost_usd=0.01,
+                lines_added=10,
+                lines_removed=5,
+                session_id=sid,
+                model_id="claude-opus-4-6",
+                workspace_project_dir="/home/user/project",
+                context_window_size=200000,
+            )
+            state_file = tmp_path / f"statusline.{sid}.state"
+            state_file.write_text(entry.to_csv_line() + "\n")
+            import os
+
+            # session-c most recent, session-a oldest
+            os.utime(state_file, (now - (2 - i) * 30, now - (2 - i) * 30))
+
+        with patch.object(StateFile, "STATE_DIR", tmp_path):
+            run_sessions(5, colors)
+
+        output = capsys.readouterr().out
+        # session-c should appear before session-a in output
+        pos_c = output.find("session-c")
+        pos_a = output.find("session-a")
+        assert pos_c < pos_a, "Most recent session should appear first"

--- a/tests/python/test_sessions.py
+++ b/tests/python/test_sessions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import time
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -65,9 +64,7 @@ class TestNormalizeArgv:
         assert "mi" in remaining
 
     def test_session_and_flags(self):
-        action, session_id, remaining = _normalize_argv(
-            ["abc123", "graph", "--no-watch"]
-        )
+        action, session_id, remaining = _normalize_argv(["abc123", "graph", "--no-watch"])
         assert action == "graph"
         assert session_id == "abc123"
         assert "--no-watch" in remaining
@@ -79,9 +76,7 @@ class TestNormalizeArgv:
         assert "--no-color" in remaining
 
     def test_sessions_with_minutes(self):
-        action, session_id, remaining = _normalize_argv(
-            ["sessions", "--minutes", "30"]
-        )
+        action, session_id, remaining = _normalize_argv(["sessions", "--minutes", "30"])
         assert action == "sessions"
         assert session_id is None
         assert "--minutes" in remaining


### PR DESCRIPTION
Closes #60

## Summary

- Makes `session-id` optional for all commands — when omitted, the most recent session is used automatically
- Adds a new `sessions` command that lists recent sessions with metadata
- Running `context-stats` with no arguments now shows graphs for the latest session

## Approach

Modified `_normalize_argv()` to treat the first positional as an action (not session_id) when it matches a known action name. When no session_id is provided, `None` is passed through to `StateFile(None)` which already resolves the latest session via `find_latest_state_file()`.

Added `run_sessions()` which scans state files by modification time, filters by a configurable `--minutes` window (default: 5), and displays session metadata (project name, model, token count, time ago).

## Changes

| File | Change |
|------|--------|
| `src/claude_statusline/cli/context_stats.py` | Made session-id optional in `_normalize_argv`, added `sessions` to `_KNOWN_ACTIONS`, added `run_sessions()` handler, updated help text, resolved latest session for `cache-warm` when None |
| `tests/python/test_sessions.py` | 18 tests covering `_normalize_argv` with optional session-id and `run_sessions` listing |

## Test Results

420 tests passed (402 existing + 18 new) — zero regressions.

## Acceptance Criteria

- [x] Default to the latest session when `session-id` is omitted
- [x] Add a command to list recent sessions (`sessions`)
- [x] `--minutes N` flag to configure the time window (default: 5)
- [x] Sessions ordered from most recent to oldest
- [x] Each entry shows how long ago the last data was received
- [x] Backward-compatible — users who pass explicit session IDs see no change