### PR TITLE
feat(statusline): add tok/s model throughput display (#70)

### DIFF
--- a/.gitissue/analysis-70.json
+++ b/.gitissue/analysis-70.json
@@ -1,0 +1,35 @@
+{
+  "issue": 70,
+  "title": "Add tok/s (tokens/sec) display to statusline",
+  "type": "feature",
+  "complexity": "medium",
+  "decision_record": {
+    "gating_fact": "Claude Code's statusline JSON exposes `cost.total_api_duration_ms` (\"Total time spent waiting for API responses\" — pure model generation time, excludes user idle/tool/thinking time). This is confirmed by the repo's own fixture tests/fixtures/json/valid_full.json and the official Claude Code statusline docs. The existing code never reads this field.",
+    "data_constraint": "Per official docs, as of Claude Code v2.1.132 `context_window.total_output_tokens` reflects CURRENT context usage, not cumulative session totals. Therefore total_output_tokens (cumulative-looking) cannot be paired with cumulative total_api_duration_ms. However `current_usage.output_tokens` has ALWAYS meant 'this request's output' and is version-stable.",
+    "chosen_formula": "tok/s = current_usage.output_tokens / (delta(total_api_duration_ms) / 1000), where delta is between the current row and the previous persisted CSV row. Per-response numerator matched to per-response API-time delta. Excludes idle/tool time -> genuine model throughput.",
+    "rejected_alternatives": [
+      "CSV-delta of context tokens / wall-clock time: folds user idle time into denominator, fails AC#2 'accurate current throughput', misrepresents 'speed of the model'.",
+      "Single-snapshot total_output_tokens / total_api_duration_ms: only valid pre-v2.1.132 (when output was cumulative); divides point-in-time numerator by cumulative denominator on current versions -> garbage."
+    ],
+    "csv_change": "Requires persisting total_api_duration_ms as a NEW CSV field index 14 (15th field). Backward-compatible: all readers (core/state.py from_csv_line, scripts hand-indexing) use len(parts) > N guards, so old 14-field rows parse with new field defaulting to 0, and old readers ignore the extra field. CSV_FORMAT.md bumped 14 -> 15.",
+    "config": "New keys (default OFF, like show_mi): show_tps (bool), tps_precision (int, default 1), tps_unit (str, default 'tok/s'). Added in BOTH config paths.",
+    "guards": [
+      "delta_api > 0 before dividing (avoid div-by-zero on same-response double refresh)",
+      "prev_api_duration > 0 required (skip display one cycle after upgrade so we difference two REAL readings, not 0 vs cumulative)",
+      "cost.total_api_duration_ms absent in minimal payloads / old CC versions -> hide tok/s gracefully",
+      "widen outer state read/write gate from `show_delta or show_mi` to `... or show_tps` so tok/s-alone still reads prev row and persists api_duration"
+    ]
+  },
+  "sync_points": [
+    "scripts/statusline.py: read_config dict + parse branches + inline conf template + JSON read + state_data write list + prev-row hand-index (csv_parts[14]) + render segment + outer gate",
+    "src/claude_statusline/cli/statusline.py: JSON read + StateEntry build + render segment + outer gate",
+    "src/claude_statusline/core/state.py: StateEntry dataclass field + from_csv_line (parts[14], len-guarded) + to_csv_line",
+    "src/claude_statusline/core/config.py: dataclass fields + _read_config branches + to_dict + minimal fallback + data/statusline.conf.default",
+    "shared compute helper: graphs/statistics.py (package) + compute_tps() (standalone)"
+  ],
+  "acceptance_criteria": [
+    "Statusline displays model throughput as tok/s while a model is running -> compute fn + render segment in both paths",
+    "Clear units ('tok/s') and reflects current throughput; accurate -> per-response api_duration delta, idle excluded",
+    "Config to enable/disable + formatting (unit, precision) -> show_tps + tps_unit + tps_precision in both config paths"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,10 @@ The following logic is duplicated between the installable package (`src/`) and t
 | Per-property colors | `colors.py:ColorManager` props, `config.py:_COLOR_KEYS` | `_COLOR_KEYS`, per-property vars |
 | Compaction detection | `graphs/statistics.py:detect_compaction_events()` | `detect_compaction_events()` |
 | Compaction constants | `core/config.py:compaction_drop_threshold`, `compact_mi_warn_threshold` | `COMPACTION_DROP_THRESHOLD`, `COMPACT_MI_WARN_THRESHOLD` |
-| tok/s compute | `graphs/statistics.py:compute_tps()`, `format_tps()` | `compute_tps()`, `format_tps()` |
-| tok/s config | `core/config.py:show_tps`, `tps_precision`, `tps_unit` | `read_config()` `show_tps`/`tps_precision`/`tps_unit` |
-| tok/s state field | `core/state.py:StateEntry.api_duration_ms` (CSV index 14) | `state_data` list + `csv_parts[14]` prev-read |
+| tok/s compute (rolling, token-weighted avg over N turns) | `graphs/statistics.py:compute_tps(samples, window)`, `format_tps()` | `compute_tps(samples, window)`, `format_tps()` |
+| tok/s config | `core/config.py:show_tps`, `tps_precision`, `tps_unit`, `tps_window` | `read_config()` `show_tps`/`tps_precision`/`tps_unit`/`tps_window` |
+| tok/s state field | `core/state.py:StateEntry.api_duration_ms` (CSV index 14) | `state_data` list + `csv_parts[14]` |
+| tok/s rolling read | `cli/statusline.py` `read_history()` → `(output, api_duration_ms)` samples | full-file read building `tps_samples` from index 4 + 14 |
 
 ## Cross-References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,9 @@ The following logic is duplicated between the installable package (`src/`) and t
 | Per-property colors | `colors.py:ColorManager` props, `config.py:_COLOR_KEYS` | `_COLOR_KEYS`, per-property vars |
 | Compaction detection | `graphs/statistics.py:detect_compaction_events()` | `detect_compaction_events()` |
 | Compaction constants | `core/config.py:compaction_drop_threshold`, `compact_mi_warn_threshold` | `COMPACTION_DROP_THRESHOLD`, `COMPACT_MI_WARN_THRESHOLD` |
+| tok/s compute | `graphs/statistics.py:compute_tps()`, `format_tps()` | `compute_tps()`, `format_tps()` |
+| tok/s config | `core/config.py:show_tps`, `tps_precision`, `tps_unit` | `read_config()` `show_tps`/`tps_precision`/`tps_unit` |
+| tok/s state field | `core/state.py:StateEntry.api_duration_ms` (CSV index 14) | `state_data` list + `csv_parts[14]` prev-read |
 
 ## Cross-References
 

--- a/docs/CSV_FORMAT.md
+++ b/docs/CSV_FORMAT.md
@@ -1,6 +1,6 @@
 # CSV State File Format
 
-State files are stored at `~/.claude/statusline/statusline.<session_id>.state`. Each line is a CSV record with 14 comma-separated fields.
+State files are stored at `~/.claude/statusline/statusline.<session_id>.state`. Each line is a CSV record with 15 comma-separated fields.
 
 ## Field Specification
 
@@ -20,6 +20,7 @@ State files are stored at `~/.claude/statusline/statusline.<session_id>.state`. 
 | 11 | `model_id` | string | Model identifier (e.g., `claude-opus-4-5`) |
 | 12 | `workspace_project_dir` | string | Project directory path (commas replaced with underscores) |
 | 13 | `context_window_size` | integer | Context window size in tokens |
+| 14 | `api_duration_ms` | integer | Cumulative API wait time in milliseconds (`cost.total_api_duration_ms`); powers the tok/s throughput display |
 
 ## Constraints
 
@@ -35,8 +36,10 @@ State files are stored at `~/.claude/statusline/statusline.<session_id>.state`. 
 
 Older state files may contain 2-field lines: `timestamp,total_input_tokens`. The reader defaults all other fields to zero/empty for these lines.
 
+State files written before the `api_duration_ms` field was added contain 14 fields (through `context_window_size`). The reader defaults `api_duration_ms` to `0` for these lines, and field access is length-guarded so both 14- and 15-field rows parse correctly. Conversely, older readers ignore the extra trailing field, so the change is backward-compatible in both directions.
+
 ## Example
 
 ```
-1710288000,75000,8500,50000,5000,10000,20000,0.05234,250,45,abc-123-def,claude-opus-4-5,/home/user/my-project,200000
+1710288000,75000,8500,50000,5000,10000,20000,0.05234,250,45,abc-123-def,claude-opus-4-5,/home/user/my-project,200000,5000
 ```

--- a/examples/statusline.conf
+++ b/examples/statusline.conf
@@ -79,6 +79,33 @@ show_mi=false
 mi_curve_beta=0
 
 
+# ─── Model Throughput (tok/s) ───────────────────────────────────────────────
+#
+# Displays the model's generation speed in tokens per second (e.g., 42.5 tok/s).
+# Speed is measured from the time spent waiting for API responses
+# (cost.total_api_duration_ms), so it reflects pure model throughput and
+# excludes your idle time, tool execution, and thinking. It updates once a new
+# API response has been received and is hidden until a reading is available.
+#
+# Like MI, this requires state file I/O for tracking across refreshes.
+
+# Show model throughput in the statusline (e.g., 42.5 tok/s).
+#   false = throughput hidden (default)
+#   true  = throughput visible
+show_tps=false
+
+# Number of decimal places for the throughput value.
+#   0 -> "42 tok/s"
+#   1 -> "42.5 tok/s" (default)
+#   2 -> "42.53 tok/s"
+tps_precision=1
+
+# Unit label appended after the throughput value.
+#   tok/s    (default)
+#   tokens/s (more explicit)
+tps_unit=tok/s
+
+
 # ─── Zone Threshold Overrides ───────────────────────────────────────────────
 #
 # Zones indicate how much context pressure your session is under:

--- a/examples/statusline.conf
+++ b/examples/statusline.conf
@@ -84,8 +84,13 @@ mi_curve_beta=0
 # Displays the model's generation speed in tokens per second (e.g., 42.5 tok/s).
 # Speed is measured from the time spent waiting for API responses
 # (cost.total_api_duration_ms), so it reflects pure model throughput and
-# excludes your idle time, tool execution, and thinking. It updates once a new
-# API response has been received and is hidden until a reading is available.
+# excludes your idle time, tool execution, and thinking.
+#
+# The value is a rolling, token-weighted average over the last few turns (see
+# tps_window), not the raw per-turn speed — per-turn speed swings wildly (a
+# 3-token reply looks like 1.5 tok/s, a long answer like 80 tok/s), so the
+# average is far steadier and tracks the genuine "speed of the model". Once
+# established it persists across turns that carry no new timing info.
 #
 # Like MI, this requires state file I/O for tracking across refreshes.
 
@@ -104,6 +109,12 @@ tps_precision=1
 #   tok/s    (default)
 #   tokens/s (more explicit)
 tps_unit=tok/s
+
+# Number of recent turns averaged for the rolling throughput.
+#   Larger  = steadier, slower to react to a speed change.
+#   Smaller = more responsive, slightly jumpier. Minimum 1.
+#   5 = default
+tps_window=5
 
 
 # ─── Zone Threshold Overrides ───────────────────────────────────────────────

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -24,7 +24,7 @@ State file format (CSV):
   timestamp,total_input_tokens,total_output_tokens,current_usage_input_tokens,
   current_usage_output_tokens,current_usage_cache_creation,current_usage_cache_read,
   total_cost_usd,total_lines_added,total_lines_removed,session_id,model_id,
-  workspace_project_dir,context_window_size
+  workspace_project_dir,context_window_size,total_api_duration_ms
 """
 
 import json
@@ -105,6 +105,44 @@ def compute_mi(used_tokens, context_window_size, model_id="", beta_override=0.0)
     if u <= 0:
         return 1.0
     return max(0.0, 1.0 - u**beta)
+
+
+def compute_tps(current_output_tokens, api_duration_ms, prev_api_duration_ms):
+    """Compute model throughput in tokens per second.
+
+    Throughput = most recent response's output tokens / the API time that
+    response took. API time comes from the delta of the cumulative
+    cost.total_api_duration_ms ("time spent waiting for API responses")
+    between the current and previous state rows, so it excludes user idle
+    time, tool execution, and thinking — genuine model generation speed.
+
+    The numerator uses current_usage.output_tokens (this response's output),
+    not a cumulative total: as of Claude Code v2.1.132,
+    context_window.total_output_tokens reflects current context usage rather
+    than a session total, while current_usage.output_tokens has always meant
+    "this request" and stays aligned with the per-response API-time delta.
+
+    Returns tokens/second, or None when it cannot be computed meaningfully
+    (no output, no prior reading, or non-positive elapsed API time) — None
+    means "hide the display this cycle".
+    """
+    # Need a real previous reading. A zero previous value means no prior row
+    # or a legacy row without the field; differencing against it understates.
+    if prev_api_duration_ms <= 0:
+        return None
+    delta_ms = api_duration_ms - prev_api_duration_ms
+    if delta_ms <= 0:
+        # Same response refreshed twice, or no new API time elapsed.
+        return None
+    if current_output_tokens <= 0:
+        return None
+    return current_output_tokens / (delta_ms / 1000.0)
+
+
+def format_tps(tps, precision=1, unit="tok/s"):
+    """Format a tokens-per-second value for display (e.g. '42.5 tok/s')."""
+    precision = max(0, precision)
+    return f"{tps:.{precision}f} {unit}"
 
 
 def get_mi_color(mi, utilization=0.0):
@@ -419,6 +457,9 @@ def read_config():
         "reduced_motion": False,
         "show_mi": False,
         "mi_curve_beta": 0.0,
+        "show_tps": False,
+        "tps_precision": 1,
+        "tps_unit": "tok/s",
         "colors": {},
         "zone_config": {},
         "compaction_drop_threshold": COMPACTION_DROP_THRESHOLD,
@@ -512,6 +553,33 @@ show_mi=false
 # Set to 0 to use the model-specific profile (recommended).
 # Set a positive value (e.g., 1.5) to override for all models.
 mi_curve_beta=0
+
+
+# ─── Model Throughput (tok/s) ───────────────────────────────────────────────
+#
+# Displays the model's generation speed in tokens per second (e.g., 42.5 tok/s).
+# Speed is measured from the time spent waiting for API responses
+# (cost.total_api_duration_ms), so it reflects pure model throughput and
+# excludes your idle time, tool execution, and thinking. It updates once a new
+# API response has been received and is hidden until a reading is available.
+#
+# Like MI, this requires state file I/O for tracking across refreshes.
+
+# Show model throughput in the statusline (e.g., 42.5 tok/s).
+#   false = throughput hidden (default)
+#   true  = throughput visible
+show_tps=false
+
+# Number of decimal places for the throughput value.
+#   0 -> "42 tok/s"
+#   1 -> "42.5 tok/s" (default)
+#   2 -> "42.53 tok/s"
+tps_precision=1
+
+# Unit label appended after the throughput value.
+#   tok/s    (default)
+#   tokens/s (more explicit)
+tps_unit=tok/s
 
 
 # ─── Zone Threshold Overrides ───────────────────────────────────────────────
@@ -622,20 +690,21 @@ color_separator=dim
 #
 # The statusline elements are displayed in this order (highest priority first):
 #
-#   project_name | branch [changes] | tokens_free (%) | Zone | MI:score | +delta | Model | session_id
+#   project_name | branch [changes] | tokens_free (%) | Zone | MI:score | tok/s | +delta | Model | session_id
 #
 # Example output:
-#   my-project | main [3] | 64,000 free (32.0%) | Code | MI:0.918 | +2,500 | Opus 4.6 | abc-123
+#   my-project | main [3] | 64,000 free (32.0%) | Code | MI:0.918 | 42.5 tok/s | +2,500 | Opus 4.6 | abc-123
 #
 # If the terminal is too narrow, lower-priority elements are dropped:
 #   1. session_id   (dropped first)
 #   2. model name
 #   3. token delta
-#   4. MI score
-#   5. zone indicator
-#   6. context info
-#   7. git info
-#   8. project name  (always shown, never dropped)
+#   4. tok/s throughput
+#   5. MI score
+#   6. zone indicator
+#   7. context info
+#   8. git info
+#   9. project name  (always shown, never dropped)
 """
                 )
         except Exception as e:
@@ -674,6 +743,26 @@ color_separator=dim
                         config["mi_curve_beta"] = float(raw_value)
                     except ValueError:
                         pass
+                elif key == "show_tps":
+                    config["show_tps"] = value_lower != "false"
+                elif key == "tps_precision":
+                    try:
+                        v = int(raw_value)
+                        if v >= 0:
+                            config["tps_precision"] = v
+                        else:
+                            sys.stderr.write(
+                                f"[statusline] warning: tps_precision must be >= 0, "
+                                f"ignoring '{raw_value}'\n"
+                            )
+                    except ValueError:
+                        sys.stderr.write(
+                            f"[statusline] warning: invalid integer for tps_precision: "
+                            f"'{raw_value}'\n"
+                        )
+                elif key == "tps_unit":
+                    if raw_value:
+                        config["tps_unit"] = raw_value
                 elif key in _COLOR_KEYS:
                     ansi = _parse_color(raw_value)
                     if ansi:
@@ -746,6 +835,9 @@ def main():
     show_session = config["show_session"]
     show_mi = config["show_mi"]
     mi_curve_beta = config["mi_curve_beta"]
+    show_tps = config["show_tps"]
+    tps_precision = config["tps_precision"]
+    tps_unit = config["tps_unit"]
     # Note: show_io_tokens setting is read but not yet implemented
 
     # Apply color overrides from config
@@ -776,6 +868,7 @@ def main():
     context_info = ""
     delta_info = ""
     mi_info = ""
+    tps_info = ""
     zone_info = ""
     session_info = ""
     total_size = data.get("context_window", {}).get("context_window_size", 0)
@@ -785,6 +878,7 @@ def main():
     cost_usd = data.get("cost", {}).get("total_cost_usd", 0)
     lines_added = data.get("cost", {}).get("total_lines_added", 0)
     lines_removed = data.get("cost", {}).get("total_lines_removed", 0)
+    api_duration_ms = data.get("cost", {}).get("total_api_duration_ms", 0)
     model_id = data.get("model", {}).get("id", "")
     workspace_project_dir = data.get("workspace", {}).get("project_dir", "")
 
@@ -833,8 +927,10 @@ def main():
         effective_zone_color = c.get("zone", zone_ansi)
         zone_info = f" | {effective_zone_color}{zone_word}{RESET}"
 
-        # Read previous entry if needed for delta OR MI
-        if show_delta or show_mi:
+        # Read previous entry if needed for delta, MI, or throughput (tok/s).
+        # tok/s needs the previous row (for the API-time delta) and persists
+        # the current api_duration for the next refresh, so it widens this gate.
+        if show_delta or show_mi or show_tps:
             import glob
             import shutil
             import time
@@ -857,6 +953,7 @@ def main():
                 state_file = os.path.join(state_dir, "statusline.state")
             has_prev = False
             prev_tokens = 0
+            prev_api_duration = 0
             try:
                 if os.path.exists(state_file):
                     has_prev = True
@@ -874,12 +971,16 @@ def main():
                                 prev_cache_creation = int(csv_parts[5]) if len(csv_parts) > 5 else 0
                                 prev_cache_read = int(csv_parts[6]) if len(csv_parts) > 6 else 0
                                 prev_tokens = prev_cur_input + prev_cache_creation + prev_cache_read
+                                # Previous cumulative API wait time (CSV index 14).
+                                # Absent on legacy rows -> 0 -> tok/s hidden one cycle.
+                                prev_api_duration = int(csv_parts[14]) if len(csv_parts) > 14 else 0
                             else:
                                 # Old format - single value
                                 prev_tokens = int(last_line or 0)
             except (OSError, ValueError) as e:
                 sys.stderr.write(f"[statusline] warning: failed to read state file: {e}\n")
                 prev_tokens = 0
+                prev_api_duration = 0
 
             # Calculate and display token delta if enabled
             if show_delta:
@@ -899,6 +1000,14 @@ def main():
                 # Use per-property mi_score color if configured, else MI-based color
                 effective_mi_color = c.get("mi_score", mi_color)
                 mi_info = f" | {effective_mi_color}MI:{mi_val:.3f}{RESET}"
+
+            # Calculate and display model throughput (tok/s) if enabled
+            if show_tps:
+                cur_output = current_usage.get("output_tokens", 0)
+                tps = compute_tps(cur_output, api_duration_ms, prev_api_duration)
+                if tps is not None:
+                    tps_display = format_tps(tps, tps_precision, tps_unit)
+                    tps_info = f" | {c_separator}{tps_display}{RESET}"
 
             # Only append if context usage changed (avoid duplicates from multiple refreshes)
             if not has_prev or used_tokens != prev_tokens:
@@ -922,6 +1031,7 @@ def main():
                             model_id,
                             workspace_project_dir.replace(",", "_"),
                             total_size,
+                            api_duration_ms,
                         ]
                     )
                     with open(state_file, "a") as f:
@@ -934,12 +1044,22 @@ def main():
     if show_session and session_id:
         session_info = f" | {c_separator}{session_id}{RESET}"
 
-    # Output: directory | branch [changes] | XXk free (XX%) | zone | MI | +delta | [Model] [session_id]
+    # Output: dir | branch [changes] | XXk free (XX%) | zone | MI | tok/s | +delta | [Model] [id]
     # Model name is lowest priority — truncated first when terminal is narrow
     base = f"{c_project_name}{dir_name}{RESET}"
     model_info = f" | {c_separator}{model}{RESET}"
     max_width = get_terminal_width()
-    parts = [base, git_info, context_info, zone_info, mi_info, delta_info, model_info, session_info]
+    parts = [
+        base,
+        git_info,
+        context_info,
+        zone_info,
+        mi_info,
+        tps_info,
+        delta_info,
+        model_info,
+        session_info,
+    ]
     print(fit_to_width(parts, max_width))
 
 

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -163,7 +163,7 @@ def compute_tps(samples, window=5):
 
 def format_tps(tps, precision=1, unit="tok/s"):
     """Format a tokens-per-second value for display (e.g. '42.5 tok/s')."""
-    precision = max(0, precision)
+    precision = min(10, max(0, precision))
     return f"{tps:.{precision}f} {unit}"
 
 

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -107,36 +107,58 @@ def compute_mi(used_tokens, context_window_size, model_id="", beta_override=0.0)
     return max(0.0, 1.0 - u**beta)
 
 
-def compute_tps(current_output_tokens, api_duration_ms, prev_api_duration_ms):
-    """Compute model throughput in tokens per second.
+def compute_tps(samples, window=5):
+    """Compute a smoothed, session-rolling model throughput in tokens/second.
 
-    Throughput = most recent response's output tokens / the API time that
-    response took. API time comes from the delta of the cumulative
-    cost.total_api_duration_ms ("time spent waiting for API responses")
-    between the current and previous state rows, so it excludes user idle
-    time, tool execution, and thinking — genuine model generation speed.
+    Rather than the jumpy per-turn instantaneous speed (which swings between,
+    say, 1.5 and 80 tok/s depending on how many tokens a turn happened to
+    emit), this returns a rolling, token-weighted average over the most recent
+    turns. Weighting by output tokens means a tiny 3-token turn cannot drag the
+    number down the way a plain mean-of-ratios would — the result tracks the
+    genuine "speed of the model" across the session.
 
-    The numerator uses current_usage.output_tokens (this response's output),
-    not a cumulative total: as of Claude Code v2.1.132,
-    context_window.total_output_tokens reflects current context usage rather
-    than a session total, while current_usage.output_tokens has always meant
-    "this request" and stays aligned with the per-response API-time delta.
+    Each sample is an (output_tokens, api_duration_ms) pair from a state row
+    (plus the live reading), where api_duration_ms is the cumulative
+    cost.total_api_duration_ms ("time spent waiting for API responses" — it
+    excludes user idle time, tool execution, and thinking). A *turn* is the
+    transition between two consecutive samples: its output is that row's
+    current_usage.output_tokens and its API time is the delta of the
+    cumulative durations. Turns with a non-positive API-time delta (same
+    response refreshed twice) or non-positive output are dropped.
 
-    Returns tokens/second, or None when it cannot be computed meaningfully
-    (no output, no prior reading, or non-positive elapsed API time) — None
-    means "hide the display this cycle".
+    Average over the last `window` valid turns, token-weighted:
+
+        tok/s = sum(output) / (sum(api_time_ms) / 1000)
+
+    A turn that contributes no valid sample simply isn't in the sums, so the
+    previously established average persists ("keep last average" on missing
+    data) as long as one valid turn remains in the window.
+
+    Returns tokens/second, or None when no valid turn exists yet (first row,
+    all legacy rows, or no real API time elapsed) — None means "hide".
     """
-    # Need a real previous reading. A zero previous value means no prior row
-    # or a legacy row without the field; differencing against it understates.
-    if prev_api_duration_ms <= 0:
+    if window < 1:
+        window = 1
+    turns = []
+    for i in range(1, len(samples)):
+        prev_dur = samples[i - 1][1]
+        out, cur_dur = samples[i]
+        # A zero/negative previous cumulative means a legacy row without the
+        # field — differencing against it would understate throughput badly.
+        if prev_dur <= 0:
+            continue
+        delta_ms = cur_dur - prev_dur
+        if delta_ms <= 0 or out <= 0:
+            continue
+        turns.append((out, delta_ms))
+    if not turns:
         return None
-    delta_ms = api_duration_ms - prev_api_duration_ms
-    if delta_ms <= 0:
-        # Same response refreshed twice, or no new API time elapsed.
+    recent = turns[-window:]
+    total_output = sum(out for out, _ in recent)
+    total_ms = sum(ms for _, ms in recent)
+    if total_ms <= 0:
         return None
-    if current_output_tokens <= 0:
-        return None
-    return current_output_tokens / (delta_ms / 1000.0)
+    return total_output / (total_ms / 1000.0)
 
 
 def format_tps(tps, precision=1, unit="tok/s"):
@@ -460,6 +482,7 @@ def read_config():
         "show_tps": False,
         "tps_precision": 1,
         "tps_unit": "tok/s",
+        "tps_window": 5,
         "colors": {},
         "zone_config": {},
         "compaction_drop_threshold": COMPACTION_DROP_THRESHOLD,
@@ -560,8 +583,13 @@ mi_curve_beta=0
 # Displays the model's generation speed in tokens per second (e.g., 42.5 tok/s).
 # Speed is measured from the time spent waiting for API responses
 # (cost.total_api_duration_ms), so it reflects pure model throughput and
-# excludes your idle time, tool execution, and thinking. It updates once a new
-# API response has been received and is hidden until a reading is available.
+# excludes your idle time, tool execution, and thinking.
+#
+# The value is a rolling, token-weighted average over the last few turns (see
+# tps_window), not the raw per-turn speed — per-turn speed swings wildly (a
+# 3-token reply looks like 1.5 tok/s, a long answer like 80 tok/s), so the
+# average is far steadier and tracks the genuine "speed of the model". Once
+# established it persists across turns that carry no new timing info.
 #
 # Like MI, this requires state file I/O for tracking across refreshes.
 
@@ -580,6 +608,12 @@ tps_precision=1
 #   tok/s    (default)
 #   tokens/s (more explicit)
 tps_unit=tok/s
+
+# Number of recent turns averaged for the rolling throughput.
+#   Larger  = steadier, slower to react to a speed change.
+#   Smaller = more responsive, slightly jumpier. Minimum 1.
+#   5 = default
+tps_window=5
 
 
 # ─── Zone Threshold Overrides ───────────────────────────────────────────────
@@ -763,6 +797,20 @@ color_separator=dim
                 elif key == "tps_unit":
                     if raw_value:
                         config["tps_unit"] = raw_value
+                elif key == "tps_window":
+                    try:
+                        v = int(raw_value)
+                        if v >= 1:
+                            config["tps_window"] = v
+                        else:
+                            sys.stderr.write(
+                                f"[statusline] warning: tps_window must be >= 1, "
+                                f"ignoring '{raw_value}'\n"
+                            )
+                    except ValueError:
+                        sys.stderr.write(
+                            f"[statusline] warning: invalid integer for tps_window: '{raw_value}'\n"
+                        )
                 elif key in _COLOR_KEYS:
                     ansi = _parse_color(raw_value)
                     if ansi:
@@ -838,6 +886,7 @@ def main():
     show_tps = config["show_tps"]
     tps_precision = config["tps_precision"]
     tps_unit = config["tps_unit"]
+    tps_window = config["tps_window"]
     # Note: show_io_tokens setting is read but not yet implemented
 
     # Apply color overrides from config
@@ -953,11 +1002,14 @@ def main():
                 state_file = os.path.join(state_dir, "statusline.state")
             has_prev = False
             prev_tokens = 0
-            prev_api_duration = 0
+            # Rolling tok/s samples: (output_tokens, api_duration_ms) per row,
+            # in chronological order. Only collected when show_tps is on.
+            tps_samples = []
             try:
                 if os.path.exists(state_file):
                     has_prev = True
-                    # Read last line to get previous state
+                    # Read all lines: last line drives delta/dedup; full history
+                    # (when show_tps) feeds the rolling-average reconstruction.
                     with open(state_file) as f:
                         file_lines = f.readlines()
                         if file_lines:
@@ -971,16 +1023,27 @@ def main():
                                 prev_cache_creation = int(csv_parts[5]) if len(csv_parts) > 5 else 0
                                 prev_cache_read = int(csv_parts[6]) if len(csv_parts) > 6 else 0
                                 prev_tokens = prev_cur_input + prev_cache_creation + prev_cache_read
-                                # Previous cumulative API wait time (CSV index 14).
-                                # Absent on legacy rows -> 0 -> tok/s hidden one cycle.
-                                prev_api_duration = int(csv_parts[14]) if len(csv_parts) > 14 else 0
                             else:
                                 # Old format - single value
                                 prev_tokens = int(last_line or 0)
+                            if show_tps:
+                                # Reconstruct (output[4], api_duration[14]) for
+                                # every row. Legacy rows lack index 14 -> 0, which
+                                # compute_tps treats as "no prior reading".
+                                for line in file_lines:
+                                    parts = line.strip().split(",")
+                                    if len(parts) < 5:
+                                        continue
+                                    try:
+                                        out = int(parts[4])
+                                        dur = int(parts[14]) if len(parts) > 14 else 0
+                                    except ValueError:
+                                        continue
+                                    tps_samples.append((out, dur))
             except (OSError, ValueError) as e:
                 sys.stderr.write(f"[statusline] warning: failed to read state file: {e}\n")
                 prev_tokens = 0
-                prev_api_duration = 0
+                tps_samples = []
 
             # Calculate and display token delta if enabled
             if show_delta:
@@ -1001,10 +1064,13 @@ def main():
                 effective_mi_color = c.get("mi_score", mi_color)
                 mi_info = f" | {effective_mi_color}MI:{mi_val:.3f}{RESET}"
 
-            # Calculate and display model throughput (tok/s) if enabled
+            # Calculate and display model throughput (tok/s) if enabled — a
+            # rolling, token-weighted average over the last N turns from the
+            # state history plus the live reading.
             if show_tps:
                 cur_output = current_usage.get("output_tokens", 0)
-                tps = compute_tps(cur_output, api_duration_ms, prev_api_duration)
+                samples = tps_samples + [(cur_output, api_duration_ms)]
+                tps = compute_tps(samples, window=tps_window)
                 if tps is not None:
                     tps_display = format_tps(tps, tps_precision, tps_unit)
                     tps_info = f" | {c_separator}{tps_display}{RESET}"

--- a/src/claude_statusline/cli/statusline.py
+++ b/src/claude_statusline/cli/statusline.py
@@ -70,6 +70,7 @@ def main() -> None:
     context_info = ""
     delta_info = ""
     mi_info = ""
+    tps_info = ""
     zone_info = ""
     session_info = ""
 
@@ -80,6 +81,7 @@ def main() -> None:
     cost_usd = data.get("cost", {}).get("total_cost_usd", 0)
     lines_added = data.get("cost", {}).get("total_lines_added", 0)
     lines_removed = data.get("cost", {}).get("total_lines_removed", 0)
+    api_duration_ms = data.get("cost", {}).get("total_api_duration_ms", 0)
     model_id = data.get("model", {}).get("id", "")
     workspace_project_dir = data.get("workspace", {}).get("project_dir", "")
 
@@ -140,12 +142,16 @@ def main() -> None:
         effective_zone_color = prop_zone_color if prop_zone_color else zone_color
         zone_info = f" | {effective_zone_color}{zone_result.zone}{colors.reset}"
 
-        # State file management for delta display and history recording
-        if config.show_delta or config.show_mi:
+        # State file management for delta/MI/throughput display and history.
+        # tok/s also needs the previous row (for the API-time delta) and must
+        # persist the current api_duration for the next refresh, so it widens
+        # this gate alongside show_delta / show_mi.
+        if config.show_delta or config.show_mi or config.show_tps:
             state_file = StateFile(session_id)
             prev_entry = state_file.read_last_entry()
             has_prev = prev_entry is not None
             prev_tokens = prev_entry.current_used_tokens if prev_entry else 0
+            prev_api_duration = prev_entry.api_duration_ms if prev_entry else 0
 
             # Build current entry
             cur_input_tokens = current_usage.get("input_tokens", 0)
@@ -166,6 +172,7 @@ def main() -> None:
                 model_id=model_id,
                 workspace_project_dir=workspace_project_dir,
                 context_window_size=total_size,
+                api_duration_ms=api_duration_ms,
             )
 
             # Calculate and display token delta if enabled
@@ -191,6 +198,15 @@ def main() -> None:
                 effective_mi_color = prop_mi_color if prop_mi_color else mi_color
                 mi_info = f" | {effective_mi_color}MI:{format_mi_score(mi_score.mi)}{colors.reset}"
 
+            # Calculate model throughput (tok/s) from the API-time delta
+            if config.show_tps:
+                from claude_statusline.graphs.statistics import compute_tps, format_tps
+
+                tps = compute_tps(cur_output_tokens, api_duration_ms, prev_api_duration)
+                if tps is not None:
+                    tps_display = format_tps(tps, config.tps_precision, config.tps_unit)
+                    tps_info = f" | {colors.separator}{tps_display}{colors.reset}"
+
             # Only append if context usage changed (avoid duplicates)
             if not has_prev or used_tokens != prev_tokens:
                 state_file.append_entry(entry)
@@ -204,7 +220,17 @@ def main() -> None:
     base = f"{colors.project_name}{dir_name}{colors.reset}"
     model_info = f" | {colors.separator}{model}{colors.reset}"
     max_width = get_terminal_width()
-    parts = [base, git_info, context_info, zone_info, mi_info, delta_info, model_info, session_info]
+    parts = [
+        base,
+        git_info,
+        context_info,
+        zone_info,
+        mi_info,
+        tps_info,
+        delta_info,
+        model_info,
+        session_info,
+    ]
     print(fit_to_width(parts, max_width))
 
 

--- a/src/claude_statusline/cli/statusline.py
+++ b/src/claude_statusline/cli/statusline.py
@@ -148,10 +148,16 @@ def main() -> None:
         # this gate alongside show_delta / show_mi.
         if config.show_delta or config.show_mi or config.show_tps:
             state_file = StateFile(session_id)
-            prev_entry = state_file.read_last_entry()
+            # tok/s needs a rolling window of recent rows; delta/MI only need
+            # the last row. Read full history when tok/s is on, else last only.
+            if config.show_tps:
+                history = state_file.read_history()
+                prev_entry = history[-1] if history else None
+            else:
+                history = []
+                prev_entry = state_file.read_last_entry()
             has_prev = prev_entry is not None
             prev_tokens = prev_entry.current_used_tokens if prev_entry else 0
-            prev_api_duration = prev_entry.api_duration_ms if prev_entry else 0
 
             # Build current entry
             cur_input_tokens = current_usage.get("input_tokens", 0)
@@ -198,11 +204,15 @@ def main() -> None:
                 effective_mi_color = prop_mi_color if prop_mi_color else mi_color
                 mi_info = f" | {effective_mi_color}MI:{format_mi_score(mi_score.mi)}{colors.reset}"
 
-            # Calculate model throughput (tok/s) from the API-time delta
+            # Calculate model throughput (tok/s) as a rolling, token-weighted
+            # average over the last N turns reconstructed from state history
+            # plus the live reading.
             if config.show_tps:
                 from claude_statusline.graphs.statistics import compute_tps, format_tps
 
-                tps = compute_tps(cur_output_tokens, api_duration_ms, prev_api_duration)
+                samples = [(e.current_output_tokens, e.api_duration_ms) for e in history]
+                samples.append((cur_output_tokens, api_duration_ms))
+                tps = compute_tps(samples, window=config.tps_window)
                 if tps is not None:
                     tps_display = format_tps(tps, config.tps_precision, config.tps_unit)
                     tps_info = f" | {colors.separator}{tps_display}{colors.reset}"

--- a/src/claude_statusline/core/config.py
+++ b/src/claude_statusline/core/config.py
@@ -68,6 +68,9 @@ show_io_tokens=true
 reduced_motion=false
 show_mi=false
 mi_curve_beta=0
+show_tps=false
+tps_precision=1
+tps_unit=tok/s
 """
 
 
@@ -100,6 +103,11 @@ class Config:
     reduced_motion: bool = False
     show_mi: bool = False
     mi_curve_beta: float = 0.0  # 0 = use model-specific profile default
+
+    # Model throughput display (tokens per second)
+    show_tps: bool = False
+    tps_precision: int = 1  # decimal places for the tok/s value
+    tps_unit: str = "tok/s"  # unit label appended to the value
 
     # Zone threshold overrides (0 = use defaults from intelligence.py)
     zone_1m_plan_max: int = 0
@@ -194,6 +202,26 @@ class Config:
                         self.mi_curve_beta = float(raw_value)
                     except ValueError:
                         pass
+                elif key == "show_tps":
+                    self.show_tps = value_lower != "false"
+                elif key == "tps_precision":
+                    try:
+                        v = int(raw_value)
+                        if v >= 0:
+                            self.tps_precision = v
+                        else:
+                            sys.stderr.write(
+                                f"[statusline] warning: tps_precision must be >= 0, "
+                                f"ignoring '{raw_value}'\n"
+                            )
+                    except ValueError:
+                        sys.stderr.write(
+                            f"[statusline] warning: invalid integer for tps_precision: "
+                            f"'{raw_value}'\n"
+                        )
+                elif key == "tps_unit":
+                    if raw_value:
+                        self.tps_unit = raw_value
                 elif key in _ZONE_INT_KEYS:
                     try:
                         v = int(raw_value)
@@ -262,6 +290,9 @@ class Config:
             "reduced_motion": self.reduced_motion,
             "show_mi": self.show_mi,
             "mi_curve_beta": self.mi_curve_beta,
+            "show_tps": self.show_tps,
+            "tps_precision": self.tps_precision,
+            "tps_unit": self.tps_unit,
             "zone_1m_plan_max": self.zone_1m_plan_max,
             "zone_1m_code_max": self.zone_1m_code_max,
             "zone_1m_dump_max": self.zone_1m_dump_max,

--- a/src/claude_statusline/core/config.py
+++ b/src/claude_statusline/core/config.py
@@ -71,6 +71,7 @@ mi_curve_beta=0
 show_tps=false
 tps_precision=1
 tps_unit=tok/s
+tps_window=5
 """
 
 
@@ -108,6 +109,7 @@ class Config:
     show_tps: bool = False
     tps_precision: int = 1  # decimal places for the tok/s value
     tps_unit: str = "tok/s"  # unit label appended to the value
+    tps_window: int = 5  # number of recent turns averaged for rolling tok/s
 
     # Zone threshold overrides (0 = use defaults from intelligence.py)
     zone_1m_plan_max: int = 0
@@ -222,6 +224,20 @@ class Config:
                 elif key == "tps_unit":
                     if raw_value:
                         self.tps_unit = raw_value
+                elif key == "tps_window":
+                    try:
+                        v = int(raw_value)
+                        if v >= 1:
+                            self.tps_window = v
+                        else:
+                            sys.stderr.write(
+                                f"[statusline] warning: tps_window must be >= 1, "
+                                f"ignoring '{raw_value}'\n"
+                            )
+                    except ValueError:
+                        sys.stderr.write(
+                            f"[statusline] warning: invalid integer for tps_window: '{raw_value}'\n"
+                        )
                 elif key in _ZONE_INT_KEYS:
                     try:
                         v = int(raw_value)
@@ -293,6 +309,7 @@ class Config:
             "show_tps": self.show_tps,
             "tps_precision": self.tps_precision,
             "tps_unit": self.tps_unit,
+            "tps_window": self.tps_window,
             "zone_1m_plan_max": self.zone_1m_plan_max,
             "zone_1m_code_max": self.zone_1m_code_max,
             "zone_1m_dump_max": self.zone_1m_dump_max,

--- a/src/claude_statusline/core/state.py
+++ b/src/claude_statusline/core/state.py
@@ -28,6 +28,7 @@ class StateEntry:
     model_id: str
     workspace_project_dir: str
     context_window_size: int
+    api_duration_ms: int = 0
 
     @classmethod
     def from_csv_line(cls, line: str) -> StateEntry | None:
@@ -96,6 +97,7 @@ class StateEntry:
                 model_id=parts[11] if len(parts) > 11 else "",
                 workspace_project_dir=parts[12] if len(parts) > 12 else "",
                 context_window_size=safe_int(parts[13] if len(parts) > 13 else ""),
+                api_duration_ms=safe_int(parts[14] if len(parts) > 14 else ""),
             )
 
         except (ValueError, IndexError):
@@ -120,6 +122,7 @@ class StateEntry:
                 self.model_id,
                 self.workspace_project_dir.replace(",", "_"),
                 self.context_window_size,
+                self.api_duration_ms,
             ]
         )
 

--- a/src/claude_statusline/data/statusline.conf.default
+++ b/src/claude_statusline/data/statusline.conf.default
@@ -79,6 +79,33 @@ show_mi=false
 mi_curve_beta=0
 
 
+# ─── Model Throughput (tok/s) ───────────────────────────────────────────────
+#
+# Displays the model's generation speed in tokens per second (e.g., 42.5 tok/s).
+# Speed is measured from the time spent waiting for API responses
+# (cost.total_api_duration_ms), so it reflects pure model throughput and
+# excludes your idle time, tool execution, and thinking. It updates once a new
+# API response has been received and is hidden until a reading is available.
+#
+# Like MI, this requires state file I/O for tracking across refreshes.
+
+# Show model throughput in the statusline (e.g., 42.5 tok/s).
+#   false = throughput hidden (default)
+#   true  = throughput visible
+show_tps=false
+
+# Number of decimal places for the throughput value.
+#   0 -> "42 tok/s"
+#   1 -> "42.5 tok/s" (default)
+#   2 -> "42.53 tok/s"
+tps_precision=1
+
+# Unit label appended after the throughput value.
+#   tok/s    (default)
+#   tokens/s (more explicit)
+tps_unit=tok/s
+
+
 # ─── Zone Threshold Overrides ───────────────────────────────────────────────
 #
 # Zones indicate how much context pressure your session is under:

--- a/src/claude_statusline/data/statusline.conf.default
+++ b/src/claude_statusline/data/statusline.conf.default
@@ -84,8 +84,13 @@ mi_curve_beta=0
 # Displays the model's generation speed in tokens per second (e.g., 42.5 tok/s).
 # Speed is measured from the time spent waiting for API responses
 # (cost.total_api_duration_ms), so it reflects pure model throughput and
-# excludes your idle time, tool execution, and thinking. It updates once a new
-# API response has been received and is hidden until a reading is available.
+# excludes your idle time, tool execution, and thinking.
+#
+# The value is a rolling, token-weighted average over the last few turns (see
+# tps_window), not the raw per-turn speed — per-turn speed swings wildly (a
+# 3-token reply looks like 1.5 tok/s, a long answer like 80 tok/s), so the
+# average is far steadier and tracks the genuine "speed of the model". Once
+# established it persists across turns that carry no new timing info.
 #
 # Like MI, this requires state file I/O for tracking across refreshes.
 
@@ -104,6 +109,12 @@ tps_precision=1
 #   tok/s    (default)
 #   tokens/s (more explicit)
 tps_unit=tok/s
+
+# Number of recent turns averaged for the rolling throughput.
+#   Larger  = steadier, slower to react to a speed change.
+#   Smaller = more responsive, slightly jumpier. Minimum 1.
+#   5 = default
+tps_window=5
 
 
 # ─── Zone Threshold Overrides ───────────────────────────────────────────────

--- a/src/claude_statusline/graphs/statistics.py
+++ b/src/claude_statusline/graphs/statistics.py
@@ -123,3 +123,69 @@ def calculate_deltas(values: list[int]) -> list[int]:
         deltas.append(max(0, delta))
 
     return deltas
+
+
+def compute_tps(
+    current_output_tokens: int,
+    api_duration_ms: int,
+    prev_api_duration_ms: int,
+) -> float | None:
+    """Compute model throughput in tokens per second.
+
+    Throughput is measured as the most recent API response's output tokens
+    divided by the API time that response took. The API time is derived from
+    the delta of the cumulative ``cost.total_api_duration_ms`` field between
+    the current and previous state rows. ``total_api_duration_ms`` is "time
+    spent waiting for API responses", so it excludes user idle time, tool
+    execution, and thinking — yielding genuine model generation speed.
+
+    The numerator uses ``current_usage.output_tokens`` (the most recent
+    response's output) rather than a cumulative total, because as of Claude
+    Code v2.1.132 ``context_window.total_output_tokens`` reflects current
+    context usage, not a session total. ``current_usage.output_tokens`` has
+    always meant "this request", so it stays aligned with the per-response
+    API-time delta across versions.
+
+    Args:
+        current_output_tokens: Output tokens of the most recent response
+            (``current_usage.output_tokens``).
+        api_duration_ms: Cumulative API wait time so far
+            (``cost.total_api_duration_ms``).
+        prev_api_duration_ms: Cumulative API wait time from the previous
+            state row.
+
+    Returns:
+        Throughput in tokens/second, or ``None`` when it cannot be computed
+        meaningfully (no output, no prior reading, or non-positive elapsed
+        API time). ``None`` signals "hide the display this cycle".
+    """
+    # Need a real previous reading to difference against. A zero previous
+    # value means either no prior row or a legacy row without the field —
+    # differencing against it would understate throughput badly.
+    if prev_api_duration_ms <= 0:
+        return None
+
+    delta_ms = api_duration_ms - prev_api_duration_ms
+    if delta_ms <= 0:
+        # Same response refreshed twice, or no new API time elapsed.
+        return None
+
+    if current_output_tokens <= 0:
+        return None
+
+    return current_output_tokens / (delta_ms / 1000.0)
+
+
+def format_tps(tps: float, precision: int = 1, unit: str = "tok/s") -> str:
+    """Format a tokens-per-second value for display.
+
+    Args:
+        tps: Throughput in tokens per second.
+        precision: Number of decimal places (clamped to >= 0).
+        unit: Unit label appended after the value (e.g. ``"tok/s"``).
+
+    Returns:
+        Formatted string like ``"42.5 tok/s"``.
+    """
+    precision = max(0, precision)
+    return f"{tps:.{precision}f} {unit}"

--- a/src/claude_statusline/graphs/statistics.py
+++ b/src/claude_statusline/graphs/statistics.py
@@ -200,11 +200,11 @@ def format_tps(tps: float, precision: int = 1, unit: str = "tok/s") -> str:
 
     Args:
         tps: Throughput in tokens per second.
-        precision: Number of decimal places (clamped to >= 0).
+        precision: Number of decimal places (clamped to the range 0..10).
         unit: Unit label appended after the value (e.g. ``"tok/s"``).
 
     Returns:
         Formatted string like ``"42.5 tok/s"``.
     """
-    precision = max(0, precision)
+    precision = min(10, max(0, precision))
     return f"{tps:.{precision}f} {unit}"

--- a/src/claude_statusline/graphs/statistics.py
+++ b/src/claude_statusline/graphs/statistics.py
@@ -126,54 +126,73 @@ def calculate_deltas(values: list[int]) -> list[int]:
 
 
 def compute_tps(
-    current_output_tokens: int,
-    api_duration_ms: int,
-    prev_api_duration_ms: int,
+    samples: list[tuple[int, int]],
+    window: int = 5,
 ) -> float | None:
-    """Compute model throughput in tokens per second.
+    """Compute a smoothed, session-rolling model throughput in tokens/second.
 
-    Throughput is measured as the most recent API response's output tokens
-    divided by the API time that response took. The API time is derived from
-    the delta of the cumulative ``cost.total_api_duration_ms`` field between
-    the current and previous state rows. ``total_api_duration_ms`` is "time
-    spent waiting for API responses", so it excludes user idle time, tool
-    execution, and thinking — yielding genuine model generation speed.
+    Rather than the jumpy per-turn instantaneous speed (which swings between,
+    say, 1.5 and 80 tok/s depending on how many tokens a single turn happened
+    to emit), this returns a **rolling, token-weighted average** over the most
+    recent turns. The average is weighted by output tokens, so a tiny 3-token
+    turn cannot drag the number down the way a plain mean-of-ratios would —
+    the result tracks the genuine "speed of the model" across the session.
 
-    The numerator uses ``current_usage.output_tokens`` (the most recent
-    response's output) rather than a cumulative total, because as of Claude
-    Code v2.1.132 ``context_window.total_output_tokens`` reflects current
-    context usage, not a session total. ``current_usage.output_tokens`` has
-    always meant "this request", so it stays aligned with the per-response
-    API-time delta across versions.
+    Each ``sample`` is an ``(output_tokens, api_duration_ms)`` pair taken from
+    a state row (plus the live reading), where ``api_duration_ms`` is the
+    cumulative ``cost.total_api_duration_ms`` ("time spent waiting for API
+    responses" — it excludes user idle time, tool execution, and thinking).
+    A *turn* is the transition between two consecutive samples: its output is
+    that row's ``current_usage.output_tokens`` and its API time is the delta
+    of the cumulative durations. Turns with a non-positive API-time delta
+    (same response refreshed twice) or non-positive output are dropped.
+
+    The average over the last ``window`` valid turns is token-weighted:
+
+        tok/s = Σ output_tokens / (Σ api_time_ms / 1000)
+
+    Because both sums accumulate over the kept turns, a turn that contributes
+    no valid sample simply isn't in the sums — the previously established
+    average persists ("keep last average" on missing data) as long as at least
+    one valid turn remains in the window.
 
     Args:
-        current_output_tokens: Output tokens of the most recent response
-            (``current_usage.output_tokens``).
-        api_duration_ms: Cumulative API wait time so far
-            (``cost.total_api_duration_ms``).
-        prev_api_duration_ms: Cumulative API wait time from the previous
-            state row.
+        samples: Chronological ``(output_tokens, api_duration_ms)`` pairs, one
+            per state row, with the live reading last. ``api_duration_ms`` is
+            the cumulative API wait time at that row.
+        window: Number of most-recent valid turns to average over (>= 1).
 
     Returns:
-        Throughput in tokens/second, or ``None`` when it cannot be computed
-        meaningfully (no output, no prior reading, or non-positive elapsed
-        API time). ``None`` signals "hide the display this cycle".
+        Rolling throughput in tokens/second, or ``None`` when no valid turn
+        exists yet (first row, all legacy rows, or no real API time elapsed).
+        ``None`` signals "hide the display".
     """
-    # Need a real previous reading to difference against. A zero previous
-    # value means either no prior row or a legacy row without the field —
-    # differencing against it would understate throughput badly.
-    if prev_api_duration_ms <= 0:
+    if window < 1:
+        window = 1
+
+    # Reconstruct per-turn (output, api_time_ms) from consecutive samples,
+    # keeping only turns with real elapsed API time and real output.
+    turns: list[tuple[int, int]] = []
+    for (_, prev_dur), (out, cur_dur) in zip(samples, samples[1:]):
+        # A zero/negative previous cumulative means a legacy row without the
+        # field — differencing against it would understate throughput badly.
+        if prev_dur <= 0:
+            continue
+        delta_ms = cur_dur - prev_dur
+        if delta_ms <= 0 or out <= 0:
+            continue
+        turns.append((out, delta_ms))
+
+    if not turns:
         return None
 
-    delta_ms = api_duration_ms - prev_api_duration_ms
-    if delta_ms <= 0:
-        # Same response refreshed twice, or no new API time elapsed.
+    recent = turns[-window:]
+    total_output = sum(out for out, _ in recent)
+    total_ms = sum(ms for _, ms in recent)
+    if total_ms <= 0:
         return None
 
-    if current_output_tokens <= 0:
-        return None
-
-    return current_output_tokens / (delta_ms / 1000.0)
+    return total_output / (total_ms / 1000.0)
 
 
 def format_tps(tps: float, precision: int = 1, unit: str = "tok/s") -> str:

--- a/tests/python/test_data_pipeline.py
+++ b/tests/python/test_data_pipeline.py
@@ -15,22 +15,23 @@ from claude_statusline.graphs.statistics import (
 
 def _make_entry(**kwargs) -> StateEntry:
     """Factory for StateEntry with sensible defaults."""
-    defaults = dict(
-        timestamp=1710288000,
-        total_input_tokens=75000,
-        total_output_tokens=8500,
-        current_input_tokens=50000,
-        current_output_tokens=5000,
-        cache_creation=10000,
-        cache_read=20000,
-        cost_usd=0.05234,
-        lines_added=250,
-        lines_removed=45,
-        session_id="abc-123-def",
-        model_id="claude-opus-4-5",
-        workspace_project_dir="/home/user/my-project",
-        context_window_size=200000,
-    )
+    defaults = {
+        "timestamp": 1710288000,
+        "total_input_tokens": 75000,
+        "total_output_tokens": 8500,
+        "current_input_tokens": 50000,
+        "current_output_tokens": 5000,
+        "cache_creation": 10000,
+        "cache_read": 20000,
+        "cost_usd": 0.05234,
+        "lines_added": 250,
+        "lines_removed": 45,
+        "session_id": "abc-123-def",
+        "model_id": "claude-opus-4-5",
+        "workspace_project_dir": "/home/user/my-project",
+        "context_window_size": 200000,
+        "api_duration_ms": 5000,
+    }
     defaults.update(kwargs)
     return StateEntry(**defaults)
 
@@ -59,7 +60,7 @@ def _render_summary_output(entries, deltas=None, graph_type=None):
 class TestStateEntryRoundTrip:
     """Tests for StateEntry.from_csv_line and to_csv_line."""
 
-    def test_full_14_field_round_trip(self):
+    def test_full_field_round_trip(self):
         original = _make_entry()
         csv_line = original.to_csv_line()
         parsed = StateEntry.from_csv_line(csv_line)
@@ -78,6 +79,18 @@ class TestStateEntryRoundTrip:
         assert parsed.model_id == original.model_id
         assert parsed.workspace_project_dir == original.workspace_project_dir
         assert parsed.context_window_size == original.context_window_size
+        assert parsed.api_duration_ms == original.api_duration_ms
+
+    def test_legacy_14_field_row_defaults_api_duration_to_zero(self):
+        """A pre-existing 14-field row (no api_duration_ms) parses with 0."""
+        line = (
+            "1710288000,75000,8500,50000,5000,10000,20000,0.05234,250,45,"
+            "abc-123-def,claude-opus-4-5,/home/user/my-project,200000"
+        )
+        entry = StateEntry.from_csv_line(line)
+        assert entry is not None
+        assert entry.context_window_size == 200000
+        assert entry.api_duration_ms == 0
 
     def test_old_format_two_fields(self):
         entry = StateEntry.from_csv_line("1710288000,50000")
@@ -90,12 +103,12 @@ class TestStateEntryRoundTrip:
         assert entry.context_window_size == 0
 
     def test_old_format_round_trip_expands(self):
-        """Old 2-field format expands to 14 fields on serialize."""
+        """Old 2-field format expands to the full field set on serialize."""
         entry = StateEntry.from_csv_line("1710288000,50000")
         assert entry is not None
         csv_line = entry.to_csv_line()
         parts = csv_line.split(",")
-        assert len(parts) == 14
+        assert len(parts) == 15
 
     def test_empty_string_returns_none(self):
         assert StateEntry.from_csv_line("") is None

--- a/tests/python/test_tps.py
+++ b/tests/python/test_tps.py
@@ -49,43 +49,80 @@ _IMPLS = pytest.mark.parametrize(
 
 
 class TestComputeTps:
+    """compute_tps takes chronological (output_tokens, cumulative_api_ms)
+    samples and returns a rolling, token-weighted tok/s over the last
+    ``window`` valid turns. A *turn* is the transition between two samples.
+    """
+
     @_IMPLS
-    def test_basic_throughput(self, fn):
-        # 5000 output tokens over 5000ms - 4000ms = 1000ms = 1.0s -> 5000 tok/s
-        assert fn(5000, 5000, 4000) == pytest.approx(5000.0)
+    def test_single_turn(self, fn):
+        # One transition: 5000 output over (5000-4000)ms = 1.0s -> 5000 tok/s.
+        # First sample's output is irrelevant (it's only the prev duration).
+        assert fn([(0, 4000), (5000, 5000)]) == pytest.approx(5000.0)
 
     @_IMPLS
     def test_fractional_seconds(self, fn):
         # 250 tokens over 500ms (0.5s) -> 500 tok/s
-        assert fn(250, 1500, 1000) == pytest.approx(500.0)
+        assert fn([(0, 1000), (250, 1500)]) == pytest.approx(500.0)
+
+    @_IMPLS
+    def test_token_weighted_average(self, fn):
+        # Two turns: 3000 tok over 37.5s (=80 tok/s) and 3 tok over 2s (=1.5).
+        # Mean-of-ratios would be ~40.75; token-weighted is dominated by the
+        # substantive turn: 3003 / 39.5s ~= 76.03.
+        samples = [(0, 1000), (3000, 38500), (3, 40500)]
+        assert fn(samples) == pytest.approx(3003 / 39.5)
+
+    @_IMPLS
+    def test_window_limits_turns(self, fn):
+        # Four samples -> three valid turns: 10 tok/1s, 10 tok/1s, 1000 tok/1s.
+        samples = [(0, 1000), (10, 2000), (10, 3000), (1000, 4000)]
+        # window=1 -> just the last turn: 1000 / 1.0 = 1000
+        assert fn(samples, 1) == pytest.approx(1000.0)
+        # window=3 -> token-weighted over all three: (10+10+1000)/3.0s
+        assert fn(samples, 3) == pytest.approx(1020 / 3.0)
 
     @_IMPLS
     def test_no_previous_reading_returns_none(self, fn):
-        # prev_api_duration == 0 means a legacy/first row: must not compute,
-        # otherwise the full cumulative would be treated as one response.
-        assert fn(5000, 5000, 0) is None
+        # Only one sample -> no turn at all.
+        assert fn([(5000, 5000)]) is None
 
     @_IMPLS
-    def test_negative_previous_returns_none(self, fn):
-        assert fn(5000, 5000, -10) is None
+    def test_empty_returns_none(self, fn):
+        assert fn([]) is None
 
     @_IMPLS
-    def test_zero_delta_returns_none(self, fn):
-        # Same response refreshed twice: api_duration unchanged -> hide.
-        assert fn(5000, 5000, 5000) is None
+    def test_legacy_prev_duration_skipped(self, fn):
+        # prev cumulative == 0 means a legacy/first row: that turn is dropped.
+        # Here the only turn has prev_dur 0 -> no valid turn -> None.
+        assert fn([(0, 0), (5000, 5000)]) is None
 
     @_IMPLS
-    def test_negative_delta_returns_none(self, fn):
+    def test_zero_delta_turn_dropped(self, fn):
+        # Same response refreshed twice: api_duration unchanged -> turn dropped.
+        assert fn([(0, 5000), (5000, 5000)]) is None
+
+    @_IMPLS
+    def test_negative_delta_turn_dropped(self, fn):
         # api_duration went backwards (shouldn't happen, but guard anyway).
-        assert fn(5000, 4000, 5000) is None
+        assert fn([(0, 5000), (5000, 4000)]) is None
 
     @_IMPLS
-    def test_zero_output_returns_none(self, fn):
-        assert fn(0, 5000, 4000) is None
+    def test_zero_output_turn_dropped(self, fn):
+        assert fn([(0, 4000), (0, 5000)]) is None
 
     @_IMPLS
-    def test_negative_output_returns_none(self, fn):
-        assert fn(-100, 5000, 4000) is None
+    def test_keep_last_average_when_latest_turn_invalid(self, fn):
+        # A good turn followed by a zero-output (invalid) turn: the invalid
+        # turn is simply not summed, so the prior average persists.
+        samples = [(0, 1000), (500, 1500), (0, 2000)]  # turn1 valid, turn2 dropped
+        # 500 tok / 0.5s = 1000 tok/s, unaffected by the trailing dud turn.
+        assert fn(samples) == pytest.approx(1000.0)
+
+    @_IMPLS
+    def test_window_below_one_clamped(self, fn):
+        samples = [(0, 1000), (100, 2000)]
+        assert fn(samples, 0) == pytest.approx(100.0)
 
 
 # ---------------------------------------------------------------------------
@@ -135,14 +172,23 @@ class TestPackageConfig:
         assert config.show_tps is False
         assert config.tps_precision == 1
         assert config.tps_unit == "tok/s"
+        assert config.tps_window == 5
 
     def test_tps_enabled(self, tmp_path):
         config_file = tmp_path / "statusline.conf"
-        config_file.write_text("show_tps=true\ntps_precision=2\ntps_unit=tokens/s\n")
+        config_file.write_text("show_tps=true\ntps_precision=2\ntps_unit=tokens/s\ntps_window=3\n")
         config = Config.load(config_path=config_file)
         assert config.show_tps is True
         assert config.tps_precision == 2
         assert config.tps_unit == "tokens/s"
+        assert config.tps_window == 3
+
+    def test_tps_window_invalid_ignored(self, tmp_path, capsys):
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text("tps_window=0\n")
+        config = Config.load(config_path=config_file)
+        assert config.tps_window == 5  # falls back to default
+        assert "tps_window" in capsys.readouterr().err
 
     def test_tps_in_to_dict(self, tmp_path):
         config_file = tmp_path / "statusline.conf"
@@ -151,6 +197,7 @@ class TestPackageConfig:
         assert d["show_tps"] is True
         assert d["tps_precision"] == 1
         assert d["tps_unit"] == "tok/s"
+        assert d["tps_window"] == 5
 
     def test_invalid_precision_ignored(self, tmp_path, capsys):
         config_file = tmp_path / "statusline.conf"
@@ -184,11 +231,20 @@ class TestStandaloneConfig:
 
     def test_tps_enabled(self, tmp_path, monkeypatch):
         cfg = self._read(
-            tmp_path, "show_tps=true\ntps_precision=0\ntps_unit=tokens/s\n", monkeypatch
+            tmp_path,
+            "show_tps=true\ntps_precision=0\ntps_unit=tokens/s\ntps_window=3\n",
+            monkeypatch,
         )
         assert cfg["show_tps"] is True
         assert cfg["tps_precision"] == 0
         assert cfg["tps_unit"] == "tokens/s"
+        assert cfg["tps_window"] == 3
+
+    def test_tps_window_default_and_invalid(self, tmp_path, monkeypatch):
+        assert self._read(tmp_path, "autocompact=true\n", monkeypatch)["tps_window"] == 5
+        # Below-1 and non-integer values are ignored, keeping the default.
+        assert self._read(tmp_path, "tps_window=0\n", monkeypatch)["tps_window"] == 5
+        assert self._read(tmp_path, "tps_window=nope\n", monkeypatch)["tps_window"] == 5
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +257,10 @@ def _run(input_data: dict, home: Path) -> tuple[str, int]:
     env = os.environ.copy()
     env["PYTHONUTF8"] = "1"
     env["HOME"] = str(home)
+    # On Windows, os.path.expanduser("~") resolves via USERPROFILE (then
+    # HOMEDRIVE+HOMEPATH), never HOME. Set USERPROFILE too so the temp home
+    # redirects the state/config dirs on every platform.
+    env["USERPROFILE"] = str(home)
     result = subprocess.run(
         [sys.executable, str(SCRIPT_PATH)],
         input=json.dumps(input_data),
@@ -248,18 +308,46 @@ class TestStandaloneEndToEnd:
         assert row[14] == "2000"  # api_duration_ms persisted
 
     def test_tps_rendered_on_second_invocation(self, tmp_path):
-        """Second run differences api_duration: (5000-2000)ms over 3000 tokens."""
+        """Second run yields one rolling turn: (5000-2000)ms over 3000 tokens."""
         conf = tmp_path / ".claude"
         conf.mkdir()
         (conf / "statusline.conf").write_text("show_tps=true\nshow_delta=false\n")
 
         _run(_payload(1000, 2000, 10000), tmp_path)
         # Second response: 3000 output tokens, cumulative api time now 5000ms.
-        # delta = 3000ms = 3.0s -> 3000 / 3.0 = 1000.0 tok/s
+        # One valid turn -> 3000 / ((5000-2000)/1000) = 1000.0 tok/s.
         out, code = _run(_payload(3000, 5000, 20000), tmp_path)
         assert code == 0
         clean = strip_ansi(out)
         assert "1000.0 tok/s" in clean
+
+    def test_tps_rolling_average_smooths_spiky_turns(self, tmp_path):
+        """A tiny outlier turn must not crater the rolling token-weighted avg."""
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text("show_tps=true\nshow_delta=false\ntps_precision=1\n")
+        # Turn 1: 3000 tok over (38500-1000)=37.5s  -> 80 tok/s on its own.
+        # Turn 2: 3 tok over (40500-38500)=2.0s     -> 1.5 tok/s on its own.
+        # Token-weighted rolling avg = 3003 / 39.5s = 76.0 tok/s (not ~40).
+        _run(_payload(0, 1000, 10000), tmp_path)
+        _run(_payload(3000, 38500, 20000), tmp_path)
+        out, code = _run(_payload(3, 40500, 30000), tmp_path)
+        assert code == 0
+        assert "76.0 tok/s" in strip_ansi(out)
+
+    def test_tps_window_one_uses_only_latest_turn(self, tmp_path):
+        """tps_window=1 reduces to the latest turn's instantaneous speed."""
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text(
+            "show_tps=true\nshow_delta=false\ntps_window=1\ntps_precision=1\n"
+        )
+        _run(_payload(0, 1000, 10000), tmp_path)
+        _run(_payload(3000, 38500, 20000), tmp_path)  # 80 tok/s turn
+        out, code = _run(_payload(3, 40500, 30000), tmp_path)  # 1.5 tok/s turn
+        assert code == 0
+        # window=1 -> only the last turn: 3 / 2.0s = 1.5 tok/s.
+        assert "1.5 tok/s" in strip_ansi(out)
 
     def test_tps_alone_works_without_delta_or_mi(self, tmp_path):
         """show_tps=true with show_delta/show_mi off still reads+writes state."""

--- a/tests/python/test_tps.py
+++ b/tests/python/test_tps.py
@@ -1,0 +1,299 @@
+"""Tests for the tokens-per-second (tok/s) throughput feature.
+
+Covers the shared compute/format helpers (package + standalone), config
+parsing for the new keys, and the standalone end-to-end render path that
+reads the previous state row to derive the API-time delta.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_statusline.core.config import Config
+from claude_statusline.graphs.statistics import compute_tps, format_tps
+
+SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "statusline.py"
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+
+def strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+# Load the standalone script as a module so its functions can be unit-tested
+# directly (mirrors how the package helpers are imported above).
+_spec = importlib.util.spec_from_file_location("statusline_script", SCRIPT_PATH)
+statusline_script = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(statusline_script)
+
+
+# ---------------------------------------------------------------------------
+# compute_tps — the core formula. Parametrized across both implementations so
+# the package and standalone copies are verified to stay in sync.
+# ---------------------------------------------------------------------------
+
+_IMPLS = pytest.mark.parametrize(
+    "fn",
+    [compute_tps, statusline_script.compute_tps],
+    ids=["package", "standalone"],
+)
+
+
+class TestComputeTps:
+    @_IMPLS
+    def test_basic_throughput(self, fn):
+        # 5000 output tokens over 5000ms - 4000ms = 1000ms = 1.0s -> 5000 tok/s
+        assert fn(5000, 5000, 4000) == pytest.approx(5000.0)
+
+    @_IMPLS
+    def test_fractional_seconds(self, fn):
+        # 250 tokens over 500ms (0.5s) -> 500 tok/s
+        assert fn(250, 1500, 1000) == pytest.approx(500.0)
+
+    @_IMPLS
+    def test_no_previous_reading_returns_none(self, fn):
+        # prev_api_duration == 0 means a legacy/first row: must not compute,
+        # otherwise the full cumulative would be treated as one response.
+        assert fn(5000, 5000, 0) is None
+
+    @_IMPLS
+    def test_negative_previous_returns_none(self, fn):
+        assert fn(5000, 5000, -10) is None
+
+    @_IMPLS
+    def test_zero_delta_returns_none(self, fn):
+        # Same response refreshed twice: api_duration unchanged -> hide.
+        assert fn(5000, 5000, 5000) is None
+
+    @_IMPLS
+    def test_negative_delta_returns_none(self, fn):
+        # api_duration went backwards (shouldn't happen, but guard anyway).
+        assert fn(5000, 4000, 5000) is None
+
+    @_IMPLS
+    def test_zero_output_returns_none(self, fn):
+        assert fn(0, 5000, 4000) is None
+
+    @_IMPLS
+    def test_negative_output_returns_none(self, fn):
+        assert fn(-100, 5000, 4000) is None
+
+
+# ---------------------------------------------------------------------------
+# format_tps — display formatting
+# ---------------------------------------------------------------------------
+
+_FMT_IMPLS = pytest.mark.parametrize(
+    "fn",
+    [format_tps, statusline_script.format_tps],
+    ids=["package", "standalone"],
+)
+
+
+class TestFormatTps:
+    @_FMT_IMPLS
+    def test_default_precision_and_unit(self, fn):
+        assert fn(42.567) == "42.6 tok/s"
+
+    @_FMT_IMPLS
+    def test_zero_precision(self, fn):
+        assert fn(42.567, precision=0) == "43 tok/s"
+
+    @_FMT_IMPLS
+    def test_two_precision(self, fn):
+        assert fn(42.567, precision=2) == "42.57 tok/s"
+
+    @_FMT_IMPLS
+    def test_custom_unit(self, fn):
+        assert fn(42.5, precision=1, unit="tokens/s") == "42.5 tokens/s"
+
+    @_FMT_IMPLS
+    def test_negative_precision_clamped(self, fn):
+        # Defensive: a negative precision must not raise.
+        assert fn(42.5, precision=-2) == "42 tok/s"
+
+
+# ---------------------------------------------------------------------------
+# Config parsing — package Config and standalone read_config
+# ---------------------------------------------------------------------------
+
+
+class TestPackageConfig:
+    def test_tps_defaults(self, tmp_path):
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text("autocompact=true\n")
+        config = Config.load(config_path=config_file)
+        assert config.show_tps is False
+        assert config.tps_precision == 1
+        assert config.tps_unit == "tok/s"
+
+    def test_tps_enabled(self, tmp_path):
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text("show_tps=true\ntps_precision=2\ntps_unit=tokens/s\n")
+        config = Config.load(config_path=config_file)
+        assert config.show_tps is True
+        assert config.tps_precision == 2
+        assert config.tps_unit == "tokens/s"
+
+    def test_tps_in_to_dict(self, tmp_path):
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text("show_tps=true\n")
+        d = Config.load(config_path=config_file).to_dict()
+        assert d["show_tps"] is True
+        assert d["tps_precision"] == 1
+        assert d["tps_unit"] == "tok/s"
+
+    def test_invalid_precision_ignored(self, tmp_path, capsys):
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text("tps_precision=notanumber\n")
+        config = Config.load(config_path=config_file)
+        assert config.tps_precision == 1  # falls back to default
+        assert "tps_precision" in capsys.readouterr().err
+
+    def test_negative_precision_ignored(self, tmp_path, capsys):
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text("tps_precision=-1\n")
+        config = Config.load(config_path=config_file)
+        assert config.tps_precision == 1
+        assert "tps_precision" in capsys.readouterr().err
+
+
+class TestStandaloneConfig:
+    def _read(self, tmp_path, contents, monkeypatch):
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text(contents)
+        monkeypatch.setattr(
+            os.path, "expanduser", lambda p: str(config_file) if "statusline.conf" in p else p
+        )
+        return statusline_script.read_config()
+
+    def test_tps_defaults(self, tmp_path, monkeypatch):
+        cfg = self._read(tmp_path, "autocompact=true\n", monkeypatch)
+        assert cfg["show_tps"] is False
+        assert cfg["tps_precision"] == 1
+        assert cfg["tps_unit"] == "tok/s"
+
+    def test_tps_enabled(self, tmp_path, monkeypatch):
+        cfg = self._read(
+            tmp_path, "show_tps=true\ntps_precision=0\ntps_unit=tokens/s\n", monkeypatch
+        )
+        assert cfg["show_tps"] is True
+        assert cfg["tps_precision"] == 0
+        assert cfg["tps_unit"] == "tokens/s"
+
+
+# ---------------------------------------------------------------------------
+# Standalone end-to-end: the second invocation should render tok/s using the
+# api_duration delta read from the first invocation's persisted state row.
+# ---------------------------------------------------------------------------
+
+
+def _run(input_data: dict, home: Path) -> tuple[str, int]:
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    env["HOME"] = str(home)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        input=json.dumps(input_data),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result.stdout.strip(), result.returncode
+
+
+def _payload(output_tokens: int, api_duration_ms: int, used_input: int) -> dict:
+    return {
+        "model": {"display_name": "Opus 4.6", "id": "claude-opus-4-6"},
+        "workspace": {"current_dir": "/home/user/proj", "project_dir": "/home/user/proj"},
+        "context_window": {
+            "context_window_size": 200000,
+            "current_usage": {
+                "input_tokens": used_input,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+        "cost": {"total_api_duration_ms": api_duration_ms},
+        "session_id": "tps-e2e-session",
+    }
+
+
+class TestStandaloneEndToEnd:
+    def test_tps_hidden_on_first_invocation(self, tmp_path):
+        """First run has no previous row -> no tok/s, but state is written."""
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text("show_tps=true\nshow_delta=false\n")
+
+        out, code = _run(_payload(1000, 2000, 10000), tmp_path)
+        assert code == 0
+        assert "tok/s" not in strip_ansi(out)
+
+        # State row must have been persisted (gate widened for show_tps alone).
+        state = conf / "statusline" / "statusline.tps-e2e-session.state"
+        assert state.exists()
+        row = state.read_text().strip().splitlines()[-1].split(",")
+        assert len(row) == 15
+        assert row[14] == "2000"  # api_duration_ms persisted
+
+    def test_tps_rendered_on_second_invocation(self, tmp_path):
+        """Second run differences api_duration: (5000-2000)ms over 3000 tokens."""
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text("show_tps=true\nshow_delta=false\n")
+
+        _run(_payload(1000, 2000, 10000), tmp_path)
+        # Second response: 3000 output tokens, cumulative api time now 5000ms.
+        # delta = 3000ms = 3.0s -> 3000 / 3.0 = 1000.0 tok/s
+        out, code = _run(_payload(3000, 5000, 20000), tmp_path)
+        assert code == 0
+        clean = strip_ansi(out)
+        assert "1000.0 tok/s" in clean
+
+    def test_tps_alone_works_without_delta_or_mi(self, tmp_path):
+        """show_tps=true with show_delta/show_mi off still reads+writes state."""
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text(
+            "show_tps=true\nshow_delta=false\nshow_mi=false\nshow_session=false\n"
+        )
+        _run(_payload(1000, 1000, 10000), tmp_path)
+        out, code = _run(_payload(500, 1500, 20000), tmp_path)
+        assert code == 0
+        # 500 tokens / ((1500-1000)/1000)s = 500 / 0.5 = 1000.0 tok/s
+        assert "1000.0 tok/s" in strip_ansi(out)
+
+    def test_tps_respects_precision_and_unit_config(self, tmp_path):
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text(
+            "show_tps=true\nshow_delta=false\ntps_precision=2\ntps_unit=tokens/s\n"
+        )
+        _run(_payload(1000, 1000, 10000), tmp_path)
+        out, _ = _run(_payload(333, 2000, 20000), tmp_path)
+        # 333 / ((2000-1000)/1000) = 333 / 1.0 = 333.00 tokens/s
+        assert "333.00 tokens/s" in strip_ansi(out)
+
+    def test_tps_hidden_when_no_api_duration_field(self, tmp_path):
+        """Old CC versions / minimal payloads lack total_api_duration_ms."""
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text("show_tps=true\nshow_delta=false\n")
+        payload = _payload(1000, 0, 10000)
+        del payload["cost"]["total_api_duration_ms"]
+        payload["cost"]["total_cost_usd"] = 0.01
+        _run(payload, tmp_path)
+        out, code = _run(payload, tmp_path)
+        assert code == 0
+        assert "tok/s" not in strip_ansi(out)

--- a/tests/python/test_tps.py
+++ b/tests/python/test_tps.py
@@ -158,6 +158,13 @@ class TestFormatTps:
         # Defensive: a negative precision must not raise.
         assert fn(42.5, precision=-2) == "42 tok/s"
 
+    @_FMT_IMPLS
+    def test_huge_precision_clamped(self, fn):
+        # Defensive: an absurd precision must not emit a megabyte-long field.
+        result = fn(42.5, precision=1_000_000)
+        assert result == "42.5000000000 tok/s"  # clamped to 10 decimals
+        assert len(result) < 30
+
 
 # ---------------------------------------------------------------------------
 # Config parsing — package Config and standalone read_config


### PR DESCRIPTION
## Summary

Adds an optional **tokens-per-second (tok/s)** display to the statusline, showing model generation speed in real time as a **smoothed, rolling average**. Closes #70.

## Approach

Per-turn instantaneous throughput is far too jumpy to be useful — a 3-token reply reads as ~1.5 tok/s, a long answer ~80 tok/s, and some turns carry no timing info at all. Instead the statusline shows a **rolling, token-weighted average** over the last `tps_window` turns (default 5):

```
tok/s = Σ output_tokens(recent turns) / (Σ api_time_ms(recent turns) / 1000)
```

A *turn* is the transition between two consecutive state rows: its output is that row's `current_usage.output_tokens` and its API time is the delta of the cumulative `cost.total_api_duration_ms`. Token-weighting (rather than mean-of-ratios) means a tiny outlier turn can't crater the number — the value tracks the genuine "speed of the model."

## Decision Record

- **Root cause / motivation:** The first cut computed per-response instantaneous speed (last response's tokens ÷ that response's API-time). In practice this swings between ~1.5 and ~80 tok/s turn-to-turn and frequently has no value to show — it does not convey throughput a user can read at a glance.
- **Selected option — rolling, token-weighted average.** Average the last N valid turns weighted by output tokens. Token-weighting beats mean-of-ratios: a 3000-token turn at 80 tok/s and a 3-token turn at 1.5 tok/s give `3003 / 39.5s = 76 tok/s` (dominated by the substantive turn), where mean-of-ratios would report a misleading ~40. Verified live in both render paths.
- **Options rejected:**
  - *Per-turn instantaneous* — the original approach; rejected for the jumpiness above.
  - *Mean-of-ratios over the window* — still lets a trivial turn halve the displayed speed; rejected for token-weighted.
  - *Cumulative session average* (Σ over all turns) — never reacts to a recent speed change; rejected in favor of a bounded window (`tps_window`).
  - *Wall-clock proxy* (Δcontext-tokens ÷ Δwall-clock) — folds user idle time into the denominator, misrepresenting model speed.
- **Why `total_api_duration_ms`?** The statusline JSON exposes `cost.total_api_duration_ms` = *"time spent waiting for API responses"* — pure model generation time, excluding user idle, tool execution, and thinking. Cumulative, so per-turn API time is its delta between rows.
- **Why `current_usage.output_tokens` as the per-turn numerator?** As of Claude Code v2.1.132, `context_window.total_output_tokens` reflects *current context usage*, not a session total. `current_usage.output_tokens` has always meant "this request."
- **Missing-data behavior — keep last average.** A turn with no valid sample (no api-time delta / zero output / legacy row) simply isn't summed, so the previously established window average persists. No flicker once a value is shown.
- **No new CSV field.** The rolling window is reconstructed from fields already persisted: `current_output_tokens` (index 4) and cumulative `api_duration_ms` (index 14). The 14→15 field bump (adding `total_api_duration_ms`) is the only CSV change. Backward-compatible **in both directions**: `len(parts) > N` guards default legacy 14-field rows to `0` (treated as "no prior reading"); older readers ignore the extra trailing field.
- **State gate widened** from `show_delta or show_mi` to also include `show_tps`, so tok/s works with delta and MI disabled. When tok/s is on, the package path reads full history (`read_history()`); otherwise it reads only the last row.

## Changes

| File | Change |
|---|---|
| `src/claude_statusline/graphs/statistics.py` | `compute_tps(samples, window)` rolling token-weighted average + `format_tps()` |
| `src/claude_statusline/core/state.py` | `api_duration_ms` field on `StateEntry` (CSV index 14) |
| `src/claude_statusline/core/config.py` | `show_tps` / `tps_precision` / `tps_unit` / **`tps_window`** config |
| `src/claude_statusline/cli/statusline.py` | Build samples from history; render `tps_info`; widened state gate |
| `scripts/statusline.py` | Standalone copies of all of the above (kept in sync) |
| `src/claude_statusline/data/statusline.conf.default`, `examples/statusline.conf` | Documented config keys incl. `tps_window` |
| `docs/CSV_FORMAT.md` | Field spec bumped 14 → 15, backward-compat note |
| `CLAUDE.md` | Updated sync-point table rows |
| `tests/python/test_tps.py` (new), `tests/python/test_data_pipeline.py` | rolling-average + parity + e2e tests |

## Test Results

```
471 passed
```

Tests cover: the rolling token-weighted formula and formatter across **both** implementations (package + standalone parity), token-weighting vs a tiny outlier, window limiting, drop-invalid-turn / keep-last-average semantics, both config parsers (incl. `tps_window` validation), and standalone end-to-end scenarios — including a **multi-turn smoothing** case proving an 80 + 1.5 tok/s sequence renders `76.0 tok/s`, and `tps_window=1` reducing to the latest turn. `ruff check` and `ruff format --check` are clean on the changed files.

Manually verified live in both render paths: seed turn hidden → `80.0 tok/s` → `76.0 tok/s`.

Also fixes the standalone e2e tests on **Windows**, where `os.path.expanduser("~")` resolves via `USERPROFILE` (not `HOME`); the test harness now sets `USERPROFILE` too so the temp-home redirect works on every platform.

## Acceptance Criteria Verification

| Criterion | Status | How |
|---|---|---|
| Statusline displays throughput as tok/s while a model is running | ✅ | `compute_tps()` rolling average + `tps_info` segment in both render paths |
| Clear units ("tok/s") and reflects current throughput; accurate | ✅ | Token-weighted rolling avg over recent turns; per-response API-time excludes idle/tool/thinking; unit label configurable |
| Config option to enable/disable + control formatting (unit, precision) | ✅ | `show_tps`, `tps_unit`, `tps_precision`, `tps_window` in both config paths (default off) |
