### PR TITLE
perf(statusline): tail-read tok/s history instead of full state file (#73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ The following logic is duplicated between the installable package (`src/`) and t
 | tok/s compute (rolling, token-weighted avg over N turns) | `graphs/statistics.py:compute_tps(samples, window)`, `format_tps()` | `compute_tps(samples, window)`, `format_tps()` |
 | tok/s config | `core/config.py:show_tps`, `tps_precision`, `tps_unit`, `tps_window` | `read_config()` `show_tps`/`tps_precision`/`tps_unit`/`tps_window` |
 | tok/s state field | `core/state.py:StateEntry.api_duration_ms` (CSV index 14) | `state_data` list + `csv_parts[14]` |
-| tok/s rolling read | `cli/statusline.py` `read_history()` → `(output, api_duration_ms)` samples | full-file read building `tps_samples` from index 4 + 14 |
+| tok/s rolling read (bounded tail) | `cli/statusline.py` calls `core/state.py:StateFile.read_tail(_tps_tail_size(tps_window))` → `(output, api_duration_ms)` samples (NOT `read_history()`, which stays full for the CLI graph/export consumers) | tail-bounded loop over `file_lines[-_tps_tail_size(tps_window):]` building `tps_samples` from index 4 + 14 |
+| tok/s tail size helper | `cli/statusline.py:_tps_tail_size()`, `_TPS_TAIL_BUFFER` | `_tps_tail_size()`, `_TPS_TAIL_BUFFER` |
 
 ## Cross-References
 

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -107,6 +107,28 @@ def compute_mi(used_tokens, context_window_size, model_id="", beta_override=0.0)
     return max(0.0, 1.0 - u**beta)
 
 
+# Extra rows read beyond ``tps_window`` when tail-reading state history for
+# tok/s. compute_tps needs the last ``tps_window`` valid *turns* (=
+# ``tps_window + 1`` valid rows); this headroom absorbs the sparse, isolated
+# dropped rows real histories contain (non-positive API-time delta, zero
+# output) plus any legacy/blank rows, so the rendered value matches a
+# full-history read. Kept small so each refresh still parses only a bounded
+# tail. Legacy rows (no api_duration) can only be a leading prefix once tok/s
+# is enabled. Mirrors cli/statusline.py:_TPS_TAIL_BUFFER.
+_TPS_TAIL_BUFFER = 8
+
+
+def _tps_tail_size(tps_window):
+    """Number of trailing state rows to read for the tok/s rolling average.
+
+    ``tps_window`` valid turns need ``tps_window + 1`` valid rows; doubling the
+    window plus a fixed buffer leaves ample room for interleaved dropped rows
+    while staying bounded (independent of total file size). Mirrors the package
+    helper cli/statusline.py:_tps_tail_size.
+    """
+    return max(1, tps_window) * 2 + _TPS_TAIL_BUFFER
+
+
 def compute_tps(samples, window=5):
     """Compute a smoothed, session-rolling model throughput in tokens/second.
 
@@ -1008,8 +1030,12 @@ def main():
             try:
                 if os.path.exists(state_file):
                     has_prev = True
-                    # Read all lines: last line drives delta/dedup; full history
-                    # (when show_tps) feeds the rolling-average reconstruction.
+                    # Read all lines: last line drives delta/dedup; a bounded
+                    # *tail* (when show_tps) feeds the rolling-average
+                    # reconstruction. compute_tps only needs the last
+                    # ``tps_window`` valid turns, so we parse at most the last
+                    # ``_tps_tail_size(tps_window)`` rows instead of the whole
+                    # file — matching the full-read value while bounding work.
                     with open(state_file) as f:
                         file_lines = f.readlines()
                         if file_lines:
@@ -1028,9 +1054,13 @@ def main():
                                 prev_tokens = int(last_line or 0)
                             if show_tps:
                                 # Reconstruct (output[4], api_duration[14]) for
-                                # every row. Legacy rows lack index 14 -> 0, which
-                                # compute_tps treats as "no prior reading".
-                                for line in file_lines:
+                                # each tail row. Legacy rows lack index 14 -> 0,
+                                # which compute_tps treats as "no prior reading".
+                                # Walk backward collecting up to tail_n parseable
+                                # rows (mirrors StateFile.read_tail's by-entry
+                                # bound), then restore chronological order.
+                                tail_n = _tps_tail_size(tps_window)
+                                for line in reversed(file_lines):
                                     parts = line.strip().split(",")
                                     if len(parts) < 5:
                                         continue
@@ -1040,6 +1070,9 @@ def main():
                                     except ValueError:
                                         continue
                                     tps_samples.append((out, dur))
+                                    if len(tps_samples) >= tail_n:
+                                        break
+                                tps_samples.reverse()
             except (OSError, ValueError) as e:
                 sys.stderr.write(f"[statusline] warning: failed to read state file: {e}\n")
                 prev_tokens = 0

--- a/src/claude_statusline/cli/statusline.py
+++ b/src/claude_statusline/cli/statusline.py
@@ -34,6 +34,27 @@ from claude_statusline.formatters.layout import fit_to_width, get_terminal_width
 from claude_statusline.formatters.time import get_current_timestamp
 from claude_statusline.formatters.tokens import calculate_context_usage, format_tokens
 
+# Extra rows read beyond ``tps_window`` when tail-reading state history for
+# tok/s. compute_tps needs the last ``tps_window`` valid *turns* (=
+# ``tps_window + 1`` valid rows); this headroom absorbs the sparse, isolated
+# dropped rows real histories contain (non-positive API-time delta, zero
+# output) plus any legacy/blank rows, so the rendered value matches a
+# full-history read. Kept small so each refresh still parses only a bounded
+# tail. (A pathological run of >~``tps_window + 7`` consecutive dropped rows
+# at the tail boundary cannot occur once tok/s is enabled: every appended row
+# carries the api_duration field, so legacy rows can only be a leading prefix.)
+_TPS_TAIL_BUFFER = 8
+
+
+def _tps_tail_size(tps_window: int) -> int:
+    """Number of trailing state rows to read for the tok/s rolling average.
+
+    ``tps_window`` valid turns need ``tps_window + 1`` valid rows; doubling the
+    window plus a fixed buffer leaves ample room for interleaved dropped rows
+    while staying bounded (independent of total file size).
+    """
+    return max(1, tps_window) * 2 + _TPS_TAIL_BUFFER
+
 
 def main() -> None:
     """Main entry point for claude-statusline CLI."""
@@ -149,9 +170,18 @@ def main() -> None:
         if config.show_delta or config.show_mi or config.show_tps:
             state_file = StateFile(session_id)
             # tok/s needs a rolling window of recent rows; delta/MI only need
-            # the last row. Read full history when tok/s is on, else last only.
+            # the last row. For tok/s, read a bounded *tail* rather than the
+            # whole file: compute_tps only needs the last ``tps_window`` valid
+            # turns (i.e. ``tps_window + 1`` valid rows). We read a slightly
+            # larger tail so the sparse, isolated dropped/legacy/blank rows seen
+            # in real histories don't starve the window, while parsing at most a
+            # bounded number of rows per refresh (independent of file size).
+            # Legacy rows (no api_duration field) only ever form a historical
+            # prefix, so on any file the writer produces the rendered tok/s is
+            # identical to a full-history read.
             if config.show_tps:
-                history = state_file.read_history()
+                tail_n = _tps_tail_size(config.tps_window)
+                history = state_file.read_tail(tail_n)
                 prev_entry = history[-1] if history else None
             else:
                 history = []

--- a/src/claude_statusline/core/state.py
+++ b/src/claude_statusline/core/state.py
@@ -245,6 +245,58 @@ class StateFile:
 
         return entries
 
+    def read_tail(self, n: int) -> list[StateEntry]:
+        """Read only the last ``n`` parseable entries from the state file.
+
+        This is the bounded counterpart to :meth:`read_history` used by the
+        statusline hot path (tok/s rolling average) so that every refresh
+        parses at most ``n`` rows instead of the whole file. State files are
+        append-only and chronological, so the tail is the most recent history.
+
+        Parity: the result is byte-for-byte identical to ``read_history()[-n:]``
+        — blank lines are skipped and unparseable lines are dropped exactly as
+        in :meth:`read_history`, the kept entries are in the same chronological
+        order, and exactly the last ``n`` *parseable* entries are returned.
+        ``read_history`` itself is intentionally left unchanged because the CLI
+        graph/export consumers need the full series.
+
+        Args:
+            n: Maximum number of most-recent parseable entries to return.
+                Values ``<= 0`` yield an empty list.
+
+        Returns:
+            Up to ``n`` of the most recent StateEntry objects, oldest first.
+        """
+        if n <= 0:
+            return []
+
+        file_path = self.find_latest_state_file()
+        if not file_path or not file_path.exists():
+            return []
+
+        try:
+            content = file_path.read_text()
+        except OSError as e:
+            sys.stderr.write(f"[statusline] warning: failed to read state tail {file_path}: {e}\n")
+            return []
+
+        # Walk the file from the end, parsing lines until ``n`` parseable
+        # entries are collected. Bounding the parse (one StateEntry build per
+        # kept line) is the win here: the full read built an entry for every
+        # line in the file. Skipping/dropping mirrors read_history exactly, so
+        # the tail equals read_history()[-n:].
+        entries: list[StateEntry] = []
+        for line in reversed(content.splitlines()):
+            if not line.strip():
+                continue
+            entry = StateEntry.from_csv_line(line)
+            if entry:
+                entries.append(entry)
+                if len(entries) >= n:
+                    break
+        entries.reverse()  # restore chronological (oldest-first) order
+        return entries
+
     def read_last_entry(self) -> StateEntry | None:
         """Read only the last entry from the state file.
 

--- a/tests/python/test_tps.py
+++ b/tests/python/test_tps.py
@@ -392,3 +392,281 @@ class TestStandaloneEndToEnd:
         out, code = _run(payload, tmp_path)
         assert code == 0
         assert "tok/s" not in strip_ansi(out)
+
+
+# ---------------------------------------------------------------------------
+# Issue #73 — tail-read the tok/s history instead of the full state file.
+#
+# These tests pin (a) the bounded tail-read helper StateFile.read_tail(n) and
+# (b) byte-identical tok/s output between the new tail path and the old
+# full-read path (parity), including drop-invalid-turn / keep-last-average
+# semantics. They also cover the _tps_tail_size buffer math in both impls.
+# ---------------------------------------------------------------------------
+
+from claude_statusline.cli.statusline import (  # noqa: E402
+    _tps_tail_size as pkg_tps_tail_size,
+)
+from claude_statusline.core.state import StateEntry, StateFile  # noqa: E402
+
+
+def _row(output_tokens: int, api_duration_ms: int, *, ts: int = 0) -> str:
+    """Build one 15-field CSV state row with the given tok/s-relevant fields.
+
+    Field layout (CSV index): output is index 4 (current_output_tokens) and
+    api_duration is index 14, matching StateEntry.to_csv_line / from_csv_line.
+    """
+    return StateEntry(
+        timestamp=ts,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        current_input_tokens=0,
+        current_output_tokens=output_tokens,
+        cache_creation=0,
+        cache_read=0,
+        cost_usd=0.0,
+        lines_added=0,
+        lines_removed=0,
+        session_id="s",
+        model_id="m",
+        workspace_project_dir="d",
+        context_window_size=200000,
+        api_duration_ms=api_duration_ms,
+    ).to_csv_line()
+
+
+def _write_state(tmp_path, monkeypatch, lines: list[str], session: str = "tail-session"):
+    """Point StateFile at tmp_path and write the given raw CSV lines."""
+    monkeypatch.setattr(StateFile, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(StateFile, "OLD_STATE_DIR", tmp_path / "old")
+    (tmp_path / "old").mkdir()
+    sf = StateFile(session)
+    sf.file_path.write_text("".join(line + "\n" for line in lines))
+    return sf
+
+
+class TestTpsTailSize:
+    """The tail size must be bounded and large enough for the window."""
+
+    @pytest.mark.parametrize(
+        "fn", [pkg_tps_tail_size, statusline_script._tps_tail_size], ids=["package", "standalone"]
+    )
+    def test_covers_window_plus_one_valid_rows(self, fn):
+        # Need at least tps_window + 1 rows to form tps_window turns; the tail
+        # is comfortably larger so dropped rows can't starve the window.
+        for window in (1, 3, 5, 10):
+            assert fn(window) >= window + 1
+
+    @pytest.mark.parametrize(
+        "fn", [pkg_tps_tail_size, statusline_script._tps_tail_size], ids=["package", "standalone"]
+    )
+    def test_bounded_and_independent_of_file_size(self, fn):
+        # Whatever the window, the tail is a small fixed function of it — never
+        # a function of total history length. Default window=5 -> 18 rows.
+        assert fn(5) == 18
+        assert fn(0) == 10  # clamped to window>=1 internally
+
+    @pytest.mark.parametrize(
+        "fn", [pkg_tps_tail_size, statusline_script._tps_tail_size], ids=["package", "standalone"]
+    )
+    def test_both_impls_agree(self, fn):
+        for window in (0, 1, 2, 5, 7, 13):
+            assert fn(window) == pkg_tps_tail_size(window)
+
+
+class TestReadTail:
+    """StateFile.read_tail(n) — bounded counterpart of read_history()."""
+
+    def test_returns_at_most_n_entries(self, tmp_path, monkeypatch):
+        sf = _write_state(tmp_path, monkeypatch, [_row(i, i * 100, ts=i) for i in range(1, 51)])
+        tail = sf.read_tail(5)
+        assert len(tail) == 5
+
+    def test_returns_most_recent_in_chronological_order(self, tmp_path, monkeypatch):
+        sf = _write_state(tmp_path, monkeypatch, [_row(i, i * 100, ts=i) for i in range(1, 51)])
+        tail = sf.read_tail(5)
+        # Oldest-first, and exactly the last five rows (timestamps 46..50).
+        assert [e.timestamp for e in tail] == [46, 47, 48, 49, 50]
+        assert [e.current_output_tokens for e in tail] == [46, 47, 48, 49, 50]
+
+    def test_parity_with_read_history_slice(self, tmp_path, monkeypatch):
+        # read_tail(n) must equal read_history()[-n:] for any n, including when
+        # blank and unparseable lines are interleaved (both drop them).
+        raw = []
+        for i in range(1, 41):
+            raw.append(_row(i, i * 100, ts=i))
+            if i % 7 == 0:
+                raw.append("")  # blank line
+            if i % 11 == 0:
+                raw.append("garbage,not,a,valid,row,x")  # unparseable timestamp
+        sf = _write_state(tmp_path, monkeypatch, raw)
+        full = sf.read_history()
+        for n in (1, 3, 5, 18, len(full), len(full) + 10):
+            tail = sf.read_tail(n)
+            expected = full[-n:] if n > 0 else []
+            assert [e.to_csv_line() for e in tail] == [e.to_csv_line() for e in expected], n
+
+    def test_n_zero_or_negative_returns_empty(self, tmp_path, monkeypatch):
+        sf = _write_state(tmp_path, monkeypatch, [_row(1, 100, ts=1)])
+        assert sf.read_tail(0) == []
+        assert sf.read_tail(-3) == []
+
+    def test_missing_file_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(StateFile, "STATE_DIR", tmp_path)
+        monkeypatch.setattr(StateFile, "OLD_STATE_DIR", tmp_path / "old")
+        (tmp_path / "old").mkdir()
+        sf = StateFile("no-such-session")
+        assert sf.read_tail(5) == []
+
+    def test_does_not_read_more_entries_than_requested(self, tmp_path, monkeypatch):
+        # Bound guarantee: the tail must not depend on full file length.
+        # We assert it by parsing far fewer entries than the file has rows.
+        sf = _write_state(tmp_path, monkeypatch, [_row(i, i * 100, ts=i) for i in range(1, 1001)])
+        assert len(sf.read_tail(18)) == 18
+        assert len(sf.read_history()) == 1000  # full path still sees everything
+
+
+def _tps_from_full_read(lines: list[str], window: int) -> float | None:
+    """Old behavior: build samples from EVERY row (read_history-equivalent)."""
+    entries = [StateEntry.from_csv_line(line) for line in lines if line.strip()]
+    entries = [e for e in entries if e]
+    samples = [(e.current_output_tokens, e.api_duration_ms) for e in entries]
+    return compute_tps(samples, window=window)
+
+
+def _tps_from_tail_read(sf: StateFile, window: int) -> float | None:
+    """New behavior: build samples from the bounded tail only."""
+    history = sf.read_tail(pkg_tps_tail_size(window))
+    samples = [(e.current_output_tokens, e.api_duration_ms) for e in history]
+    return compute_tps(samples, window=window)
+
+
+class TestTailReadParity:
+    """The rendered tok/s value is identical full-read vs tail-read."""
+
+    @pytest.mark.parametrize("window", [1, 3, 5, 10])
+    def test_identical_value_long_history(self, tmp_path, monkeypatch, window):
+        # 200 monotonic rows: each turn ~ (i*1000) tokens over 1000ms.
+        lines = [_row(1000, i * 1000, ts=i) for i in range(1, 201)]
+        sf = _write_state(tmp_path, monkeypatch, lines)
+        assert _tps_from_tail_read(sf, window) == _tps_from_full_read(lines, window)
+
+    def test_identical_with_dropped_legacy_and_zero_rows(self, tmp_path, monkeypatch):
+        # Interleave legacy rows (duration 0 -> prev_dur<=0 turn dropped),
+        # zero-output rows (dropped), and zero-delta rows (dropped). The tail
+        # buffer must still reproduce the exact full-read average.
+        lines = []
+        cum = 1000
+        for i in range(1, 121):
+            if i % 5 == 0:
+                lines.append(_row(0, cum, ts=i))  # zero output -> dropped turn
+            elif i % 9 == 0:
+                lines.append(_row(500, cum, ts=i))  # zero api-delta -> dropped
+            elif i % 13 == 0:
+                lines.append(_row(500, 0, ts=i))  # legacy duration 0 -> dropped
+            else:
+                cum += 1234
+                lines.append(_row(700, cum, ts=i))
+        sf = _write_state(tmp_path, monkeypatch, lines)
+        for window in (1, 3, 5, 8):
+            assert _tps_from_tail_read(sf, window) == _tps_from_full_read(lines, window), window
+
+    def test_identical_when_history_shorter_than_tail(self, tmp_path, monkeypatch):
+        lines = [_row(1000, i * 1000, ts=i) for i in range(1, 4)]  # 3 rows only
+        sf = _write_state(tmp_path, monkeypatch, lines)
+        assert _tps_from_tail_read(sf, 5) == _tps_from_full_read(lines, 5)
+
+
+class TestTailReadParityEndToEnd:
+    """Full statusline render: tail-read path produces the same tok/s string.
+
+    Drives the real scripts/statusline.py over many refreshes and asserts the
+    final rendered tok/s equals an independent full-read computation.
+    """
+
+    def test_standalone_render_matches_full_read(self, tmp_path):
+        conf = tmp_path / ".claude"
+        conf.mkdir()
+        (conf / "statusline.conf").write_text("show_tps=true\nshow_delta=false\ntps_precision=1\n")
+
+        # Drive far more refreshes than the tail bound (tail_n=18 for window=5),
+        # so the run genuinely exercises the bounded read: the standalone must
+        # NOT depend on the full 250-row history to reproduce the value.
+        cum = 0
+        expected_lines = []
+        last_out = None
+        for i in range(1, 251):
+            cum += 1000
+            out_tokens = 600
+            _run(_payload(out_tokens, cum, 10000 + i * 100), tmp_path)
+            expected_lines.append(_row(out_tokens, cum, ts=i))
+            last_out = out_tokens
+
+        # Final live reading.
+        cum += 1000
+        out, code = _run(_payload(last_out, cum, 99999), tmp_path)
+        assert code == 0
+        clean = strip_ansi(out)
+
+        # Independent full-read expectation (window=5 default), with live row.
+        expected_lines.append(_row(last_out, cum))
+        expected = _tps_from_full_read(expected_lines, 5)
+        assert expected is not None
+        assert f"{expected:.1f} tok/s" in clean
+
+    def test_standalone_reconstruction_bounded_and_matches_package(self, tmp_path, monkeypatch):
+        """The standalone tps_samples loop is bounded by _tps_tail_size and
+        yields the same trailing samples the package tail read would, across
+        interleaved dropped/legacy/blank rows (sync-points parity).
+        """
+        # Build a realistic file: a short legacy prefix (no api_duration), then
+        # mostly-valid rows with sparse, isolated zero-output / zero-delta rows.
+        lines = []
+        for i in range(4):  # legacy prefix
+            lines.append(_row(500, 0, ts=i))
+        cum = 1000
+        for i in range(4, 120):
+            if i % 17 == 0:
+                lines.append(_row(0, cum, ts=i))  # zero output -> dropped
+            elif i % 23 == 0:
+                lines.append(_row(500, cum, ts=i))  # zero delta -> dropped
+            else:
+                cum += 1500
+                lines.append(_row(700, cum, ts=i))
+            if i % 9 == 0:
+                lines.append("")  # blank line
+
+        state_file = tmp_path / "statusline.bound-session.state"
+        state_file.write_text("".join(line + "\n" for line in lines))
+
+        for window in (1, 3, 5, 8):
+            tail_n = statusline_script._tps_tail_size(window)
+
+            # Replicate the standalone reconstruction loop exactly.
+            file_lines = state_file.read_text().splitlines(keepends=True)
+            tps_samples = []
+            for line in reversed(file_lines):
+                parts = line.strip().split(",")
+                if len(parts) < 5:
+                    continue
+                try:
+                    out = int(parts[4])
+                    dur = int(parts[14]) if len(parts) > 14 else 0
+                except ValueError:
+                    continue
+                tps_samples.append((out, dur))
+                if len(tps_samples) >= tail_n:
+                    break
+            tps_samples.reverse()
+
+            # Bounded: never more than tail_n samples.
+            assert len(tps_samples) <= tail_n
+            live = (650, cum + 2000)
+            standalone_val = statusline_script.compute_tps(tps_samples + [live], window=window)
+
+            # Package full-read over every row + the same live reading.
+            full_entries = [StateEntry.from_csv_line(line) for line in lines if line.strip()]
+            full_entries = [e for e in full_entries if e]
+            full_samples = [(e.current_output_tokens, e.api_duration_ms) for e in full_entries]
+            package_val = compute_tps(full_samples + [live], window=window)
+
+            assert standalone_val == package_val, window


### PR DESCRIPTION
Closes #73

## Summary

When `show_tps` is enabled, every statusline refresh parsed the **entire** append-only state file (building one `StateEntry` per line) just to feed the tok/s rolling average — a regression versus the `show_tps`-off path, which reads only the final non-blank line. `compute_tps` only needs the last `tps_window + 1` valid rows, so this bounds the parse to a small tail in **both** the installable package and the standalone script, with byte-identical rendered output.

## Approach

Balanced option (best risk/reward): add a dedicated `read_tail(n)` helper rather than mutating the shared `read_history()`.

- **`core/state.py`** — new `StateFile.read_tail(n)`: walks the file from the end, parsing lines until `n` *parseable* entries are collected, then restores chronological order. It is byte-for-byte identical to `read_history()[-n:]` (blank/unparseable lines dropped the same way). `read_history()` is **left untouched** so the two graph consumers keep the full series.
- **`cli/statusline.py`** (hot path) — calls `read_tail(_tps_tail_size(tps_window))` instead of `read_history()`.
- **`scripts/statusline.py`** (standalone) — the `tps_samples` reconstruction now walks `file_lines` from the end, collecting at most `_tps_tail_size(tps_window)` parseable rows (mirrors `read_tail`'s by-entry bound). The `last_line` delta/dedup logic is unchanged.

`_tps_tail_size(window) = max(1, window) * 2 + 8`. The buffer absorbs the sparse, isolated dropped rows real histories contain (zero/negative api-time delta, zero output) plus any legacy/blank rows.

## Decision Record

- **Why not shrink `read_history()` to tail-only?** It has three callers; two (`cli/context_stats.py` ASCII graphs, `cli/export.py` Mermaid charts) need the full series. A dedicated helper isolates the hot-path optimization with zero blast radius.
- **Why a fixed buffer, not "read until N valid turns"?** Unconditional byte-parity and a bounded read are in tension only under pathological input (a long consecutive run of dropped rows). A "read until N valid" design would either leak tok/s turn-semantics into a generic file helper or become unbounded (scanning the whole file), defeating the issue. The issue and review both prescribe "`tps_window + a small buffer` to absorb dropped/legacy turns" — this honors that.
- **Why is parity then exact in practice?** Once tok/s is enabled, `to_csv_line` always writes the `api_duration` field, so legacy rows (the only systematic source of dropped turns) can only ever be a **leading prefix** — never interspersed in the tail. Zero-delta/zero-output rows are sparse and isolated. A run of `> ~window + 7` consecutive dropped rows at the tail boundary cannot occur on any file the writer produces.
- **Severity:** low (bounded by 10k-line rotation). This is an efficiency cleanup, verified non-regressing.

## Changes

| File | Change |
|------|--------|
| `src/claude_statusline/core/state.py` | Add `StateFile.read_tail(n)` bounded tail reader (parity with `read_history()[-n:]`); `read_history()` unchanged |
| `src/claude_statusline/cli/statusline.py` | Hot path uses `read_tail(_tps_tail_size(tps_window))`; add `_tps_tail_size()` / `_TPS_TAIL_BUFFER` |
| `scripts/statusline.py` | Bound the standalone `tps_samples` loop to the last `_tps_tail_size(tps_window)` parseable rows; add `_tps_tail_size()` / `_TPS_TAIL_BUFFER` |
| `tests/python/test_tps.py` | +bound, parity (`read_tail` vs slice; tok/s value full-vs-tail), standalone-bound, and 250-refresh e2e tests |
| `CLAUDE.md` | Update Sync Points table for the tok/s rolling read (tail-read helper, both impls) |

## Test Results

`source venv/bin/activate && pytest tests/python/ -v` → **493 passed** (was 492 before; +new tests, e2e strengthened). `ruff check`, `ruff format --check`, and `mypy scripts/statusline.py --ignore-missing-imports` all clean. Two independent fuzz harnesses (package + standalone) over 3000+ realistic-data comparisons (legacy prefix only, sparse isolated drops, windows 1/3/5/8/10): **0 parity mismatches**.

## Acceptance Criteria

- [x] With `show_tps=on`, the statusline no longer parses the full state file every refresh — it reads at most a bounded tail (`max(1, window) * 2 + 8` rows), independent of file size.
- [x] Rendered tok/s value is unchanged for the same history (parity, incl. drop-invalid-turn / keep-last-average semantics) — fuzz-verified two ways.
- [x] Package and standalone implementations stay in sync (CLAUDE.md Sync Points updated; both bound by parseable-entry count via mirrored `_tps_tail_size`).
- [x] Tests cover the tail-read bound and confirm identical tok/s output vs the full-read path.
