### PR TITLE
feat(graphs): add throughput (tokens/s) trend graph (#72)

### DIFF
--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -17,7 +17,8 @@ Actions:
     cache-warm  Keep session prompt cache alive via a background heartbeat
 
 Options:
-    --type <cumulative|delta|io|both|all>  Graph type to display (default: delta)
+    --type <cumulative|delta|io|cache|mi|tps|both|all>  Graph type (default: delta)
+    --minutes N                             Limit --type tps trend to last N minutes
     --watch, -w [interval]                  Real-time monitoring mode (default: 2s)
     --no-color                              Disable color output
     --version, -V                           Show version and exit
@@ -37,7 +38,13 @@ from claude_statusline.core.colors import ColorManager
 from claude_statusline.core.config import Config
 from claude_statusline.core.state import StateFile, _validate_session_id
 from claude_statusline.graphs.renderer import GraphDimensions, GraphRenderer
-from claude_statusline.graphs.statistics import calculate_deltas, detect_compaction_events
+from claude_statusline.graphs.statistics import (
+    calculate_deltas,
+    compute_tps,
+    compute_tps_series,
+    detect_compaction_events,
+    format_tps,
+)
 from claude_statusline.ui.icons import get_activity_tier, get_tier_label
 from claude_statusline.ui.waiting import get_waiting_text, is_active
 
@@ -86,8 +93,10 @@ GRAPH OPTIONS:
                    - io: Input/output tokens over time
                    - cache: Cache creation/read tokens over time
                    - mi: Model Intelligence score over time
+                   - tps: Throughput (tokens/s) trend over time
                    - both: Show cumulative and delta graphs
-                   - all: Show all graphs including I/O, cache, and MI
+                   - all: Show all graphs including I/O, cache, MI, and tps
+    --minutes N    For --type tps: limit the trend to the last N minutes
     -w [interval]  Set refresh interval in seconds (default: 2)
     --no-watch     Show graphs once and exit (disable live monitoring)
 
@@ -124,6 +133,12 @@ EXAMPLES:
 
     # Show only cumulative graph
     context-stats abc123def graph --type cumulative
+
+    # Show the throughput (tokens/s) trend graph
+    context-stats graph --type tps
+
+    # Throughput trend limited to the last 5 minutes
+    context-stats graph --type tps --minutes 5
 
     # Show graphs with custom refresh interval
     context-stats abc123def graph -w 5
@@ -239,9 +254,18 @@ def _build_graph_parser() -> argparse.ArgumentParser:
     parser.add_argument("session_id", nargs="?", default=None, help="Session ID")
     parser.add_argument(
         "--type",
-        choices=["cumulative", "delta", "io", "cache", "mi", "both", "all"],
+        choices=["cumulative", "delta", "io", "cache", "mi", "tps", "both", "all"],
         default="delta",
         help="Graph type (default: delta)",
+    )
+    parser.add_argument(
+        "--minutes",
+        type=int,
+        default=None,
+        help=(
+            "For --type tps: limit the throughput trend to the last N minutes "
+            "of history (default: all available history)"
+        ),
     )
     parser.add_argument(
         "--watch",
@@ -311,6 +335,109 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
+# Scale factor for rendering fractional tok/s values through the integer-based
+# timeseries renderer (mirrors the MI graph's int(mi * 10000) trick). Two
+# decimal places of throughput precision survive the round-trip.
+_TPS_RENDER_SCALE = 100
+
+
+def _filter_entries_by_minutes(entries: list, minutes: int | None) -> list:
+    """Return entries within the last ``minutes`` of recorded history.
+
+    The window is anchored to the *latest entry's* timestamp rather than
+    wall-clock time, so it works identically on a live session and on a
+    historical one being inspected after the fact. ``minutes`` of ``None`` (or
+    non-positive) means "no filtering — use the full history".
+
+    Args:
+        entries: Chronological list of StateEntry objects (oldest first).
+        minutes: Window size in minutes, or None for the full history.
+
+    Returns:
+        The trailing slice of *entries* whose timestamps fall within the
+        window. Always preserves chronological order.
+    """
+    if not entries or minutes is None or minutes <= 0:
+        return entries
+    cutoff = entries[-1].timestamp - minutes * 60
+    return [e for e in entries if e.timestamp >= cutoff]
+
+
+def _render_tps_graph(
+    entries: list,
+    renderer: GraphRenderer,
+    colors: ColorManager,
+    config: Config,
+    minutes: int | None = None,
+) -> None:
+    """Render the throughput (tokens/s) trend graph plus current + average.
+
+    Plots one instantaneous throughput point per valid turn over the selected
+    time window, then prints the current (latest-turn) speed and the average
+    computed across the *displayed* window. Reuses
+    :func:`compute_tps_series` / :func:`compute_tps` for the math and
+    ``render_timeseries`` for the drawing — no new graph engine.
+
+    Args:
+        entries: Chronological StateEntry list (oldest first).
+        renderer: GraphRenderer used to draw the timeseries.
+        colors: ColorManager for styling the current/average summary lines.
+        config: Config supplying tok/s display precision and unit.
+        minutes: Optional time window (last N minutes of history) to inspect.
+    """
+    windowed = _filter_entries_by_minutes(entries, minutes)
+    samples = [(e.current_output_tokens, e.api_duration_ms) for e in windowed]
+    series = compute_tps_series(samples)
+
+    range_label = f" (last {minutes}m)" if minutes else ""
+
+    if not series:
+        renderer._emit()
+        renderer._emit(f"{colors.bold}Throughput Trend (tokens/s){range_label}{colors.reset}")
+        renderer._emit(
+            f"  {colors.dim}No throughput data yet — keep using Claude Code to "
+            f"accumulate timing samples.{colors.reset}"
+        )
+        return
+
+    # Align each plotted value with the timestamp of its turn's later sample,
+    # building both lists in lockstep so dropped turns never desynchronise the
+    # value series from the x-axis labels.
+    tps_values = [tps for _, tps in series]
+    tps_times = [windowed[idx].timestamp for idx, _ in series]
+
+    # Scale fractional tok/s into integers for the int-based renderer, then
+    # format back to the real value on the Y-axis (same pattern as the MI graph).
+    scaled = [int(round(v * _TPS_RENDER_SCALE)) for v in tps_values]
+    precision = config.tps_precision
+    unit = config.tps_unit
+    renderer.render_timeseries(
+        scaled,
+        tps_times,
+        f"Throughput Trend (tokens/s){range_label}",
+        colors.green,
+        label_fn=lambda v: f"{v / _TPS_RENDER_SCALE:.{min(10, max(0, precision))}f}",
+    )
+
+    # Current = the latest valid turn's instantaneous speed.
+    # Average = token-weighted average across the entire displayed window.
+    current = tps_values[-1]
+    average = compute_tps(samples, window=len(samples))
+
+    renderer._emit()
+    renderer._emit(
+        f"  {colors.cyan}{'Current:':<12}{colors.reset} "
+        f"{format_tps(current, precision, unit)}"
+    )
+    if average is not None:
+        renderer._emit(
+            f"  {colors.magenta}{'Average:':<12}{colors.reset} "
+            f"{format_tps(average, precision, unit)}"
+            f"  {colors.dim}(over {len(tps_values)} turn"
+            f"{'s' if len(tps_values) != 1 else ''}{range_label}){colors.reset}"
+        )
+
+
 def render_once(
     state_file: StateFile,
     graph_type: str,
@@ -319,6 +446,7 @@ def render_once(
     watch_mode: bool = False,
     config: Config | None = None,
     cycle_index: int = 0,
+    minutes: int | None = None,
 ) -> bool | str:
     """Render graphs once.
 
@@ -330,6 +458,7 @@ def render_once(
         watch_mode: Whether running in watch mode
         config: Config instance for motion settings
         cycle_index: Watch mode refresh counter for rotating text
+        minutes: Optional time window (last N minutes) for the tps trend graph
 
     Returns:
         True if rendering was successful (non-watch mode),
@@ -479,6 +608,10 @@ def render_once(
             last = entries[-1]
             mi_score = calculate_intelligence(last, last.context_window_size, last.model_id, beta)
 
+    # Throughput (tokens/s) trend graph (#72)
+    if graph_type in ("tps", "all"):
+        _render_tps_graph(entries, renderer, colors, mi_config, minutes=minutes)
+
     # Compute MI at each compaction point for quality assessment (#65)
     compaction_events: list[tuple[int, float]] = []
     if compaction_indices and entries:
@@ -530,6 +663,7 @@ def run_watch_mode(
     renderer: GraphRenderer,
     colors: ColorManager,
     config: Config | None = None,
+    minutes: int | None = None,
 ) -> None:
     """Run in watch mode with continuous refresh.
 
@@ -540,6 +674,7 @@ def run_watch_mode(
         renderer: GraphRenderer instance
         colors: ColorManager instance
         config: Config instance for motion settings
+        minutes: Optional time window (last N minutes) for the tps trend graph
     """
 
     # Signal handler for clean exit
@@ -595,6 +730,7 @@ def run_watch_mode(
                     watch_mode=True,
                     config=config,
                     cycle_index=cycle_counter,
+                    minutes=minutes,
                 )
                 if isinstance(result, str):
                     buf_lines.append(result)
@@ -885,12 +1021,17 @@ def main() -> None:
     )
 
     # Run
+    minutes = getattr(args, "minutes", None)
     if args.no_watch:
-        success = render_once(state_file, args.type, renderer, colors, config=config)
+        success = render_once(
+            state_file, args.type, renderer, colors, config=config, minutes=minutes
+        )
         if not success:
             sys.exit(1)
     else:
-        run_watch_mode(state_file, args.type, args.watch, renderer, colors, config=config)
+        run_watch_mode(
+            state_file, args.type, args.watch, renderer, colors, config=config, minutes=minutes
+        )
 
 
 if __name__ == "__main__":

--- a/src/claude_statusline/graphs/statistics.py
+++ b/src/claude_statusline/graphs/statistics.py
@@ -195,6 +195,53 @@ def compute_tps(
     return total_output / (total_ms / 1000.0)
 
 
+def compute_tps_series(
+    samples: list[tuple[int, int]],
+) -> list[tuple[int, float]]:
+    """Build a per-turn instantaneous throughput series for trend plotting.
+
+    Where :func:`compute_tps` collapses the recent turns into a single rolling
+    number for the live statusline, this returns *one throughput point per
+    valid turn* so the trend can be graphed over time. Each point is the
+    instantaneous tok/s of a single turn, which is exactly what surfaces
+    regressions and spikes (the motivation in issue #72).
+
+    A *turn* is the transition between two consecutive ``samples``. The
+    per-turn speed is computed by delegating to ``compute_tps(pair, 1)``, so
+    the drop rules stay in one place: turns against a legacy/first row
+    (cumulative duration ``<= 0``), with a non-positive API-time delta (same
+    response refreshed twice), or with non-positive output are dropped and
+    simply omitted from the series — never plotted as a zero.
+
+    Each returned tuple is ``(sample_index, tokens_per_second)`` where
+    ``sample_index`` is the index *into ``samples``* of the turn's *later*
+    sample (i.e. the row whose output was produced). Callers use that index to
+    line up the matching timestamp for the x-axis, which is why the index is
+    returned alongside the value rather than discarded — a dropped turn must
+    not desynchronise values from their timestamps.
+
+    Args:
+        samples: Chronological ``(output_tokens, api_duration_ms)`` pairs, one
+            per state row, oldest first. ``api_duration_ms`` is the cumulative
+            API wait time at that row (CSV index 14).
+
+    Returns:
+        Chronological list of ``(sample_index, tok_per_second)`` for every
+        valid turn. Empty when no valid turn exists (first row, all-legacy
+        history, or no real API time elapsed).
+    """
+    series: list[tuple[int, float]] = []
+    for i in range(1, len(samples)):
+        # Reuse the single-turn path so the legacy/zero-delta/zero-output drop
+        # semantics are inherited verbatim from compute_tps rather than
+        # re-implemented here.
+        tps = compute_tps([samples[i - 1], samples[i]], window=1)
+        if tps is None:
+            continue
+        series.append((i, tps))
+    return series
+
+
 def format_tps(tps: float, precision: int = 1, unit: str = "tok/s") -> str:
     """Format a tokens-per-second value for display.
 

--- a/tests/python/test_tps_trend.py
+++ b/tests/python/test_tps_trend.py
@@ -1,0 +1,311 @@
+"""Tests for the throughput (tokens/s) trend graph — issue #72.
+
+Covers:
+  * compute_tps_series — the per-turn throughput series used for plotting,
+    including the inherited drop rules and value/timestamp index alignment.
+  * _filter_entries_by_minutes — time-range (last N minutes) selection anchored
+    to the latest entry's timestamp.
+  * _render_tps_graph / render_once --type tps — the rendered output: graph
+    title, current + average summary lines, the empty/no-data path, and that
+    the time window narrows the displayed average.
+  * CLI wiring — `tps` is an accepted --type and --minutes parses.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from claude_statusline.cli.context_stats import (
+    _build_graph_parser,
+    _filter_entries_by_minutes,
+    _render_tps_graph,
+    render_once,
+)
+from claude_statusline.core.colors import ColorManager
+from claude_statusline.core.config import Config
+from claude_statusline.core.state import StateEntry, StateFile
+from claude_statusline.graphs.renderer import GraphRenderer
+from claude_statusline.graphs.statistics import compute_tps, compute_tps_series
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+
+def strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _entry(output_tokens: int, api_duration_ms: int, *, ts: int) -> StateEntry:
+    """Build a StateEntry with the tok/s-relevant fields set.
+
+    output is current_output_tokens (CSV index 4); api time is api_duration_ms
+    (CSV index 14) — the same two fields compute_tps consumes.
+    """
+    return StateEntry(
+        timestamp=ts,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        current_input_tokens=0,
+        current_output_tokens=output_tokens,
+        cache_creation=0,
+        cache_read=0,
+        cost_usd=0.0,
+        lines_added=0,
+        lines_removed=0,
+        session_id="s",
+        model_id="claude-opus-4-6",
+        workspace_project_dir="/home/user/proj",
+        context_window_size=200000,
+        api_duration_ms=api_duration_ms,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_tps_series — per-turn throughput points for plotting
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTpsSeries:
+    def test_single_valid_turn(self):
+        # One transition: 5000 output over (5000-4000)ms = 1.0s -> 5000 tok/s.
+        # The point's index is that of the LATER sample (index 1).
+        assert compute_tps_series([(0, 4000), (5000, 5000)]) == [(1, pytest.approx(5000.0))]
+
+    def test_multiple_turns_values_and_indices(self):
+        # Three turns, each over 1s: 10, 20, 30 tok/s, at later-sample indices 1,2,3.
+        samples = [(0, 1000), (10, 2000), (20, 3000), (30, 4000)]
+        series = compute_tps_series(samples)
+        assert [idx for idx, _ in series] == [1, 2, 3]
+        assert [pytest.approx(v) for _, v in series] == [10.0, 20.0, 30.0]
+
+    def test_empty_and_single_sample(self):
+        assert compute_tps_series([]) == []
+        assert compute_tps_series([(5000, 5000)]) == []
+
+    def test_legacy_prev_row_dropped(self):
+        # prev cumulative <= 0 means a legacy/first row -> that turn is dropped.
+        assert compute_tps_series([(0, 0), (5000, 5000)]) == []
+
+    def test_zero_delta_and_zero_output_turns_dropped(self):
+        # zero api-time delta and zero-output turns are omitted (not zeroed).
+        assert compute_tps_series([(0, 5000), (5000, 5000)]) == []  # zero delta
+        assert compute_tps_series([(0, 4000), (0, 5000)]) == []  # zero output
+
+    def test_dropped_turn_does_not_desync_indices(self):
+        # Middle turn is invalid (zero output); the surviving points must keep
+        # their true sample indices so the x-axis stays aligned.
+        samples = [
+            (0, 1000),  # idx 0
+            (100, 2000),  # idx 1: valid -> 100/1s = 100
+            (0, 3000),  # idx 2: zero output -> DROPPED
+            (300, 4000),  # idx 3: valid -> 300/1s = 300
+        ]
+        series = compute_tps_series(samples)
+        assert [idx for idx, _ in series] == [1, 3]
+        assert [pytest.approx(v) for _, v in series] == [100.0, 300.0]
+
+
+# ---------------------------------------------------------------------------
+# _filter_entries_by_minutes — time-range selection (AC3)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterByMinutes:
+    def test_none_or_zero_returns_all(self):
+        entries = [_entry(10, 1000, ts=t) for t in (0, 60, 120)]
+        assert _filter_entries_by_minutes(entries, None) == entries
+        assert _filter_entries_by_minutes(entries, 0) == entries
+        assert _filter_entries_by_minutes(entries, -5) == entries
+
+    def test_window_anchored_to_latest_timestamp(self):
+        # Latest ts = 1000s. A 5-minute (300s) window keeps ts >= 700.
+        entries = [_entry(10, 1000, ts=t) for t in (0, 600, 700, 900, 1000)]
+        kept = _filter_entries_by_minutes(entries, 5)
+        assert [e.timestamp for e in kept] == [700, 900, 1000]
+
+    def test_empty_list(self):
+        assert _filter_entries_by_minutes([], 5) == []
+
+
+# ---------------------------------------------------------------------------
+# Rendering — _render_tps_graph and render_once --type tps
+# ---------------------------------------------------------------------------
+
+
+def _capture(renderer: GraphRenderer, fn) -> str:
+    """Run a renderer-emitting callable with buffering on and return output."""
+    renderer.begin_buffering()
+    fn()
+    return strip_ansi(renderer.get_buffer())
+
+
+def _renderer() -> GraphRenderer:
+    return GraphRenderer(colors=ColorManager(enabled=False), token_detail=True)
+
+
+class TestRenderTpsGraph:
+    def test_renders_title_current_and_average(self):
+        renderer = _renderer()
+        colors = ColorManager(enabled=False)
+        config = Config()
+        # Two turns over 1s each: 100 tok/s then 300 tok/s.
+        entries = [
+            _entry(0, 1000, ts=0),
+            _entry(100, 2000, ts=10),
+            _entry(300, 3000, ts=20),
+        ]
+        out = _capture(renderer, lambda: _render_tps_graph(entries, renderer, colors, config))
+        assert "Throughput Trend (tokens/s)" in out
+        # Current = latest turn = 300 tok/s.
+        assert "Current:" in out
+        assert "300.0 tok/s" in out
+        # Average = token-weighted over the window = (100+300)/2.0s = 200 tok/s.
+        assert "Average:" in out
+        assert "200.0 tok/s" in out
+
+    def test_no_data_emits_friendly_message(self):
+        renderer = _renderer()
+        colors = ColorManager(enabled=False)
+        config = Config()
+        # All-legacy rows (api_duration 0) -> no valid turn at all.
+        entries = [_entry(100, 0, ts=0), _entry(200, 0, ts=10)]
+        out = _capture(renderer, lambda: _render_tps_graph(entries, renderer, colors, config))
+        assert "Throughput Trend (tokens/s)" in out
+        assert "No throughput data yet" in out
+        # Must not print a current/average for a series that doesn't exist.
+        assert "Current:" not in out
+
+    def test_minutes_window_narrows_average(self):
+        renderer = _renderer()
+        colors = ColorManager(enabled=False)
+        config = Config()
+        # ts in seconds. Old slow turn far back, recent fast turns near the end.
+        # Latest ts = 1000. A 2-minute (120s) window keeps ts >= 880, i.e. only
+        # the last two rows -> one fast turn; the old slow turn is excluded.
+        entries = [
+            _entry(0, 1000, ts=0),
+            _entry(10, 2000, ts=10),  # turn: 10/1s = 10 tok/s (old, slow)
+            _entry(0, 3000, ts=900),  # carries cumulative forward into window
+            _entry(500, 3500, ts=1000),  # turn: 500/0.5s = 1000 tok/s (recent)
+        ]
+        out_all = _capture(
+            renderer, lambda: _render_tps_graph(entries, renderer, colors, config, minutes=None)
+        )
+        out_win = _capture(
+            renderer, lambda: _render_tps_graph(entries, renderer, colors, config, minutes=2)
+        )
+        # Windowed view advertises the range and yields the fast average only.
+        assert "(last 2m)" in out_win
+        assert "1000.0 tok/s" in out_win
+        # Full view's average is dragged down by the old slow turn, so it is not
+        # the pure fast number.
+        assert "1000.0 tok/s" not in out_all.split("Average:")[1]
+
+    def test_average_matches_compute_tps_over_window(self):
+        # The printed average must equal compute_tps over the displayed samples.
+        config = Config()
+        entries = [
+            _entry(0, 1000, ts=0),
+            _entry(700, 2000, ts=10),
+            _entry(300, 4000, ts=20),
+        ]
+        samples = [(e.current_output_tokens, e.api_duration_ms) for e in entries]
+        expected = compute_tps(samples, window=len(samples))
+        renderer = _renderer()
+        out = _capture(
+            renderer,
+            lambda: _render_tps_graph(entries, renderer, ColorManager(enabled=False), config),
+        )
+        assert f"{expected:.1f} tok/s" in out
+
+
+# ---------------------------------------------------------------------------
+# render_once integration with a real (monkeypatched) state file
+# ---------------------------------------------------------------------------
+
+
+def _write_state(tmp_path, monkeypatch, entries: list[StateEntry], session="trend-session"):
+    monkeypatch.setattr(StateFile, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(StateFile, "OLD_STATE_DIR", tmp_path / "old")
+    (tmp_path / "old").mkdir()
+    sf = StateFile(session)
+    sf.file_path.write_text("".join(e.to_csv_line() + "\n" for e in entries))
+    return sf
+
+
+class TestRenderOnceTps:
+    def test_render_once_tps_type(self, tmp_path, monkeypatch):
+        entries = [
+            _entry(0, 1000, ts=0),
+            _entry(100, 2000, ts=10),
+            _entry(300, 3000, ts=20),
+        ]
+        sf = _write_state(tmp_path, monkeypatch, entries)
+        renderer = _renderer()
+        result = render_once(
+            sf, "tps", renderer, ColorManager(enabled=False), watch_mode=True, config=Config()
+        )
+        assert isinstance(result, str)
+        clean = strip_ansi(result)
+        assert "Throughput Trend (tokens/s)" in clean
+        assert "300.0 tok/s" in clean  # current
+
+    def test_render_once_all_includes_tps(self, tmp_path, monkeypatch):
+        entries = [
+            _entry(0, 1000, ts=0),
+            _entry(100, 2000, ts=10),
+            _entry(300, 3000, ts=20),
+        ]
+        sf = _write_state(tmp_path, monkeypatch, entries)
+        renderer = _renderer()
+        result = render_once(
+            sf, "all", renderer, ColorManager(enabled=False), watch_mode=True, config=Config()
+        )
+        assert "Throughput Trend (tokens/s)" in strip_ansi(result)
+
+    def test_render_once_minutes_threads_through(self, tmp_path, monkeypatch):
+        entries = [
+            _entry(0, 1000, ts=0),
+            _entry(10, 2000, ts=10),
+            _entry(0, 3000, ts=900),
+            _entry(500, 3500, ts=1000),
+        ]
+        sf = _write_state(tmp_path, monkeypatch, entries)
+        renderer = _renderer()
+        result = render_once(
+            sf,
+            "tps",
+            renderer,
+            ColorManager(enabled=False),
+            watch_mode=True,
+            config=Config(),
+            minutes=2,
+        )
+        clean = strip_ansi(result)
+        assert "(last 2m)" in clean
+        assert "1000.0 tok/s" in clean
+
+
+# ---------------------------------------------------------------------------
+# CLI argument wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCliWiring:
+    def test_tps_is_valid_type(self):
+        parser = _build_graph_parser()
+        args = parser.parse_args(["--type", "tps"])
+        assert args.type == "tps"
+        assert args.minutes is None
+
+    def test_minutes_parses(self):
+        parser = _build_graph_parser()
+        args = parser.parse_args(["--type", "tps", "--minutes", "15"])
+        assert args.type == "tps"
+        assert args.minutes == 15
+
+    def test_minutes_defaults_none(self):
+        parser = _build_graph_parser()
+        args = parser.parse_args([])
+        assert args.minutes is None


### PR DESCRIPTION
Closes #72

## Summary
Adds a throughput (tokens/s) trend graph to the `context-stats` CLI so users can spot regressions, spikes, and long-term changes in model processing speed. A new `--type tps` renders an ASCII trend of per-turn throughput over time with tokens/s axis labels, and prints the current instantaneous speed plus a token-weighted average over the displayed window. A `--minutes N` flag selects the time range. The new graph is also included in `--type all` and updates live in watch mode.

## Approach
Translated the issue's web-flavoured wording into this project's terminal/CLI idiom (per repo architecture — it's a statusline/CLI tool, not a web app):
- "time-series graph with tokens/s labels" → ASCII trend via the existing `render_timeseries` (scaled-int + `label_fn`, exactly like the MI graph).
- "select a time range (1m/5m/1h/24h)" → `--minutes N` flag, anchored to the **latest entry's** timestamp so it works on historical sessions too.
- "current instantaneous value + average over the window" → current = latest valid turn; average = token-weighted `compute_tps` over the displayed samples.

Reused existing helpers rather than reinventing: `compute_tps`/`format_tps` and `read_history`, plus a new pure `compute_tps_series` that derives the per-turn series by delegating to `compute_tps([pair], 1)` — so the legacy / zero-delta / zero-output drop rules are inherited verbatim. Values and x-axis timestamps are built in lockstep, so dropped turns never desync the axis. Package-only; the standalone `scripts/statusline.py` (statusline hot path, no graph machinery) is untouched, so there is no dual-implementation sync burden.

## Decision Record
- **Window = time range, not turn count.** AC3 names "1 minute, 5 minutes, 1 hour, 24 hours"; a `--minutes` filter satisfies that. Anchored to the latest entry's timestamp (not wall-clock) so historical inspection works.
- **Per-turn instantaneous series** (not the rolling-5 statusline number) is plotted — that's what surfaces spikes/regressions, the stated motivation.
- **Average is over the displayed window** (`compute_tps(samples, len(samples))`), deliberately *not* the statusline's config `tps_window` rolling-5.
- **Empty/no-valid-turn case** prints a friendly "No throughput data yet" line instead of a garbage graph.
- **Skipped (low-confidence nice-to-haves):** per-second/per-minute bucketing/resolution and CSV export/smoothing overlay — left as future work to avoid over-building.

## Changes
| File | Change |
|------|--------|
| `src/claude_statusline/graphs/statistics.py` | Add `compute_tps_series(samples)` — per-turn throughput points reusing `compute_tps` drop rules |
| `src/claude_statusline/cli/context_stats.py` | Add `--type tps` + `--minutes` flag; `_render_tps_graph` and `_filter_entries_by_minutes` helpers; thread `minutes` through `render_once`/`run_watch_mode`/`main`; include `tps` in `--type all`; help/docstring/examples |
| `tests/python/test_tps_trend.py` | 19 new tests: series computation, time-range filter, current/average values, rendering output, empty-case, CLI wiring |

## Test Results
`source venv/bin/activate && pytest tests/python/ -v` → **512 passed** (493 existing + 19 new). `ruff check` on changed files: clean. Manual end-to-end smoke test confirmed the graph, current/average lines, and `--minutes` windowing render correctly through the real CLI.

## Acceptance Criteria
- [x] A "Throughput (tokens/s) Trend" graph is available without extra configuration (`--type tps`, also in `--type all`).
- [x] Plots tokens/sec over time with tokens/s axis labels; shows current instantaneous value + average over the selected window.
- [x] Users can select a time range via `--minutes N` (e.g. 1/5/60/1440). *(Sub-second/per-minute resolution bucketing intentionally deferred — see Decision Record.)*
- [x] Updates as new data arrives in watch mode (each refresh re-reads history) and preserves historical values for the window.
- [ ] (Optional/nice-to-have) CSV export / smoothing overlay — deferred as future work.
