### PR TITLE
Redesign logo + rebuild landing page with dedicated docs page

### DIFF
--- a/assets/logo/brand-showcase.html
+++ b/assets/logo/brand-showcase.html
@@ -394,35 +394,18 @@
             <div class="hero-mark">
                 <!-- Inline SVG of the canonical mark for glow effect -->
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="96" height="96">
+                    <defs>
+                        <linearGradient id="heroFill" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0" stop-color="#10B981" />
+                            <stop offset="1" stop-color="#06B6D4" />
+                        </linearGradient>
+                    </defs>
                     <rect width="64" height="64" rx="14" fill="#0F172A" />
-                    <circle cx="14" cy="50" r="3" fill="#10B981" />
-                    <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15" />
-                    <path
-                        d="M 14 50 C 14 38, 24 28, 36 28"
-                        stroke="#10B981"
-                        stroke-width="3"
-                        fill="none"
-                        stroke-linecap="round"
-                    />
-                    <path
-                        d="M 14 50 C 14 30, 28 14, 46 14"
-                        stroke="#06B6D4"
-                        stroke-width="2.5"
-                        fill="none"
-                        stroke-linecap="round"
-                        opacity="0.85"
-                    />
-                    <path
-                        d="M 14 50 C 14 22, 34 6, 56 6"
-                        stroke="#818CF8"
-                        stroke-width="2"
-                        fill="none"
-                        stroke-linecap="round"
-                        opacity="0.7"
-                    />
-                    <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6" />
-                    <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5" />
-                    <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4" />
+                    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5" />
+                    <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#heroFill)" />
+                    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4" />
+                    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8" />
+                    <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7" />
                 </svg>
             </div>
             <div class="hero-label">Brand Identity</div>
@@ -436,7 +419,7 @@
             <!-- ── Design Concept ── -->
             <section>
                 <div class="section-label">Design Concept</div>
-                <div class="section-title">Three layers of insight</div>
+                <div class="section-title">The context window, measured</div>
                 <div class="concept-grid">
                     <div class="concept-mark-card">
                         <svg
@@ -445,98 +428,72 @@
                             width="160"
                             height="160"
                         >
+                            <defs>
+                                <linearGradient id="conceptFill" x1="0" y1="0" x2="1" y2="0">
+                                    <stop offset="0" stop-color="#10B981" />
+                                    <stop offset="1" stop-color="#06B6D4" />
+                                </linearGradient>
+                            </defs>
                             <rect width="64" height="64" rx="14" fill="#0F172A" />
-                            <circle cx="14" cy="50" r="3" fill="#10B981" />
-                            <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15" />
-                            <path
-                                d="M 14 50 C 14 38, 24 28, 36 28"
-                                stroke="#10B981"
-                                stroke-width="3"
-                                fill="none"
-                                stroke-linecap="round"
-                            />
-                            <path
-                                d="M 14 50 C 14 30, 28 14, 46 14"
-                                stroke="#06B6D4"
-                                stroke-width="2.5"
-                                fill="none"
-                                stroke-linecap="round"
-                                opacity="0.85"
-                            />
-                            <path
-                                d="M 14 50 C 14 22, 34 6, 56 6"
-                                stroke="#818CF8"
-                                stroke-width="2"
-                                fill="none"
-                                stroke-linecap="round"
-                                opacity="0.7"
-                            />
-                            <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6" />
-                            <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5" />
-                            <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4" />
+                            <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5" />
+                            <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#conceptFill)" />
+                            <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4" />
+                            <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8" />
+                            <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7" />
                         </svg>
                         <div class="concept-annotations">
                             <div class="annotation-row">
+                                <div class="annotation-dot" style="background: #334155"></div>
+                                <span
+                                    ><strong style="color: #94a3b8">The frame</strong> — the context
+                                    window: your total token budget</span
+                                >
+                            </div>
+                            <div class="annotation-row">
                                 <div class="annotation-dot" style="background: #10b981"></div>
                                 <span
-                                    ><strong style="color: #10b981">Green arc</strong> — Live layer:
-                                    real-time token feedback</span
+                                    ><strong style="color: #10b981">The fill</strong> — tokens
+                                    consumed, green fading to cyan as it grows</span
                                 >
                             </div>
                             <div class="annotation-row">
                                 <div class="annotation-dot" style="background: #06b6d4"></div>
                                 <span
-                                    ><strong style="color: #06b6d4">Cyan arc</strong> — Session
-                                    layer: per-session analytics</span
+                                    ><strong style="color: #06b6d4">The cursor</strong> — your
+                                    current position in the window</span
                                 >
                             </div>
                             <div class="annotation-row">
                                 <div class="annotation-dot" style="background: #818cf8"></div>
                                 <span
-                                    ><strong style="color: #818cf8">Indigo arc</strong> — Report
-                                    layer: multi-week cost trends</span
-                                >
-                            </div>
-                            <div class="annotation-row">
-                                <div
-                                    class="annotation-dot"
-                                    style="
-                                        background: #10b981;
-                                        border: 2px solid #0f172a;
-                                        box-shadow: 0 0 0 1px #10b981;
-                                    "
-                                ></div>
-                                <span
-                                    ><strong style="color: #f1f5f9">Origin dot</strong> — The
-                                    present moment / current session</span
+                                    ><strong style="color: #818cf8">The limit</strong> — remaining
+                                    capacity before the edge</span
                                 >
                             </div>
                         </div>
                     </div>
                     <div class="concept-prose">
                         <p>
-                            The mark is built from <strong>three concentric arcs</strong> emanating
-                            from a single origin point. Each arc represents a deeper layer of
-                            analytics — from the immediate (live token feedback) to the strategic
-                            (multi-week cost reporting).
+                            The mark is a <strong>context window</strong> drawn literally — a rounded
+                            frame holding a fill gauge. It is the one thing the tool exists to show
+                            you: how much of your window is spent, and how much remains.
                         </p>
                         <p>
-                            The arcs sweep upward and to the right, suggesting
-                            <strong>expanding awareness</strong> over time. The further the arc, the
-                            broader the perspective. The origin dot anchors everything to the
-                            current moment.
+                            The fill sweeps from <strong>green to cyan</strong> as consumption grows,
+                            a <strong>cursor</strong> marks where you are right now, and an
+                            <strong>indigo tick</strong> at the far edge holds the line you are
+                            spending toward. Read left to right, it is a live progress bar.
                         </p>
                         <p>
-                            The color progression moves from <strong>green</strong> (active,
-                            healthy, live) through <strong>cyan</strong> (analytical, processed,
-                            session) to <strong>indigo</strong> (historical, deep, report). This
-                            mirrors how data ages: raw signal becomes structured insight becomes
-                            strategic pattern.
+                            The color progression moves from <strong>green</strong> (healthy,
+                            plenty left) through <strong>cyan</strong> (filling, mid-session) to
+                            <strong>indigo</strong> (the limit, the edge). The same palette the
+                            statusline uses to warn you in real time.
                         </p>
                         <p>
-                            Typography pairs <strong>Inter Bold</strong> for the product name with a
-                            spaced small-caps treatment for "STATS" — grounding the wordmark in data
-                            precision without sacrificing warmth.
+                            Typography sets <strong>Inter Bold</strong> as a single word —
+                            <strong>Context</strong> in light slate, <strong>Stats</strong> in green
+                            — so the name reads as one mark while the accent ties back to the gauge.
                         </p>
                     </div>
                 </div>

--- a/assets/logo/favicon.svg
+++ b/assets/logo/favicon.svg
@@ -2,18 +2,12 @@
   <!-- Background -->
   <rect width="16" height="16" rx="3" fill="#0F172A"/>
 
-  <!-- Simplified three-arc mark at 16×16
-       Origin at (3, 13), arcs sweep to upper-right
-       Keep outer two arcs only for clarity at tiny size -->
+  <!-- Simplified 2-layer context-window mark at 16×16:
+       outer frame + inner fill gauge (drop cursor/tick/dot detail) -->
 
-  <!-- Origin dot -->
-  <circle cx="3" cy="13" r="1" fill="#10B981"/>
+  <!-- Window frame -->
+  <rect x="2.5" y="5" width="11" height="6" rx="2" fill="none" stroke="#334155" stroke-width="1.2"/>
 
-  <!-- Arc 1 — Live (green, innermost) -->
-  <path d="M 3 13 C 3 9, 6 7, 9 7"
-        stroke="#10B981" stroke-width="1" fill="none" stroke-linecap="round"/>
-
-  <!-- Arc 2 — Report (indigo, outer) — skip cyan for clarity -->
-  <path d="M 3 13 C 3 6, 8 2, 14 2"
-        stroke="#818CF8" stroke-width="0.8" fill="none" stroke-linecap="round" opacity="0.75"/>
+  <!-- Fill gauge (green, ~55%) -->
+  <rect x="4" y="6.5" width="5" height="3" rx="1" fill="#10B981"/>
 </svg>

--- a/assets/logo/logo-black.svg
+++ b/assets/logo/logo-black.svg
@@ -1,34 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" width="320" height="72">
   <!-- Black version — no background, for use on light backgrounds -->
 
-  <!-- Mark -->
+  <!-- Mark: context-window frame geometry -->
   <g transform="translate(4, 4)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#0F172A"/>
-    <circle cx="14" cy="50" r="5.5" fill="#0F172A" opacity="0.10"/>
-
-    <!-- Arc 1 — Live -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#0F172A" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.65"/>
-
-    <!-- Arc 3 — Report -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#0F172A" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.4"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#0F172A" opacity="0.5"/>
-    <circle cx="46" cy="14" r="2" fill="#0F172A" opacity="0.35"/>
-    <circle cx="56" cy="6" r="2" fill="#0F172A" opacity="0.25"/>
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#0F172A" stroke-width="2.5" opacity="0.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="#0F172A"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#0F172A" opacity="0.8"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#0F172A" opacity="0.5"/>
+    <circle cx="48" cy="17" r="2.5" fill="#0F172A" opacity="0.45"/>
   </g>
 
   <!-- Divider -->
   <line x1="80" y1="16" x2="80" y2="56" stroke="#0F172A" stroke-width="1" opacity="0.2"/>
 
-  <!-- Wordmark -->
-  <text x="94" y="38" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#0F172A" letter-spacing="-0.5">Context</text>
-  <text x="94" y="58" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="13" font-weight="500" fill="#0F172A" letter-spacing="3.5" opacity="0.6">STATS</text>
+  <!-- Wordmark: ContextStats -->
+  <text x="94" y="44" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="24" font-weight="700" fill="#0F172A" letter-spacing="-0.5">ContextStats</text>
 </svg>

--- a/assets/logo/logo-full.svg
+++ b/assets/logo/logo-full.svg
@@ -1,35 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" width="320" height="72">
+  <defs>
+    <linearGradient id="ctxFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#10B981"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+
   <!-- Background pill -->
   <rect width="320" height="72" rx="14" fill="#0F172A"/>
 
-  <!-- Mark: three-arc analytics symbol, translated to fit 64x64 within 72px height (4px padding each side) -->
+  <!-- Mark: context-window frame, 64x64 within 72px height (4px padding) -->
   <g transform="translate(4, 4)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#10B981"/>
-    <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15"/>
-
-    <!-- Arc 1 — Live (green) -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#10B981" stroke-width="3" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session (cyan) -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#06B6D4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.85"/>
-
-    <!-- Arc 3 — Report (indigo) -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#818CF8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.7"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6"/>
-    <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5"/>
-    <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4"/>
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#ctxFill)"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8"/>
+    <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7"/>
   </g>
 
   <!-- Divider -->
   <line x1="80" y1="16" x2="80" y2="56" stroke="#334155" stroke-width="1" opacity="0.6"/>
 
-  <!-- Wordmark -->
-  <text x="94" y="38" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#F1F5F9" letter-spacing="-0.5">Context</text>
-  <text x="94" y="58" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="13" font-weight="500" fill="#10B981" letter-spacing="3.5">STATS</text>
+  <!-- Wordmark: ContextStats -->
+  <text x="94" y="44" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="24" font-weight="700" letter-spacing="-0.5"><tspan fill="#F1F5F9">Context</tspan><tspan fill="#10B981">Stats</tspan></text>
 </svg>

--- a/assets/logo/logo-icon.svg
+++ b/assets/logo/logo-icon.svg
@@ -1,31 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="ctxFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#10B981"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+
   <!-- Background: rounded square, deep navy -->
   <rect width="512" height="512" rx="96" fill="#0F172A"/>
 
-  <!-- Mark: canonical three-arc paths scaled ~6.25x, centered in 512×512
-       Base mark origin: (14,50) → translate(86, 137) scale(6.25)
-       So origin maps to: 86 + 14*6.25 = 86+87.5=173.5, 137 + 50*6.25 = 137+312.5=449.5
-       Adjusted translate to keep mark visually centered: translate(70, 90) scale(5.8) -->
-  <g transform="translate(70, 90) scale(5.8)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#10B981"/>
-    <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15"/>
-
-    <!-- Arc 1 — Live (green) -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#10B981" stroke-width="0.52" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session (cyan) -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#06B6D4" stroke-width="0.43" fill="none" stroke-linecap="round" opacity="0.85"/>
-
-    <!-- Arc 3 — Report (indigo) -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#818CF8" stroke-width="0.34" fill="none" stroke-linecap="round" opacity="0.7"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6"/>
-    <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5"/>
-    <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4"/>
+  <!-- Mark: canonical 64x64 geometry scaled 6x, centered.
+       translate(64, 64) scale(6) maps the 64-box to 384px centered in 512 -->
+  <g transform="translate(64, 64) scale(6)">
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#ctxFill)"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8"/>
+    <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7"/>
   </g>
 </svg>

--- a/assets/logo/logo-mark.svg
+++ b/assets/logo/logo-mark.svg
@@ -1,35 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
   <defs>
-    <!-- Three-level palette -->
-    <!-- Arc 1 (live):    #10B981 green  -->
-    <!-- Arc 2 (session): #06B6D4 cyan   -->
-    <!-- Arc 3 (report):  #818CF8 indigo -->
+    <!-- Palette -->
+    <!-- Base:   #0F172A slate    -->
+    <!-- Fill:   #10B981 green (consumed / live)   -->
+    <!-- Cursor: #06B6D4 cyan  (current position)  -->
+    <!-- Edge:   #818CF8 indigo (remaining / limit) -->
+    <linearGradient id="ctxFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#10B981"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
   </defs>
 
-  <!-- Background -->
+  <!-- Background tile -->
   <rect width="64" height="64" rx="14" fill="#0F172A"/>
 
-  <!-- Origin dot — "current moment" cursor -->
-  <circle cx="14" cy="50" r="3" fill="#10B981"/>
-  <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15"/>
+  <!-- Context window frame (rounded bracket outline) -->
+  <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5"/>
 
-  <!-- Arc 1 — Live (innermost, green) -->
-  <!-- Sweeps from origin upward-right, small radius ~18 -->
-  <path d="M 14 50 C 14 38, 24 28, 36 28"
-        stroke="#10B981" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Consumed fill gauge (green→cyan), ~58% of inner width -->
+  <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#ctxFill)"/>
 
-  <!-- Arc 2 — Session (middle, cyan) -->
-  <!-- Sweeps from origin upward-right, medium radius ~28 -->
-  <path d="M 14 50 C 14 30, 28 14, 46 14"
-        stroke="#06B6D4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.85"/>
+  <!-- Cursor — current position marker at the fill edge -->
+  <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4"/>
 
-  <!-- Arc 3 — Report (outermost, indigo) -->
-  <!-- Sweeps from origin upward-right, large radius ~38 -->
-  <path d="M 14 50 C 14 22, 34 6, 56 6"
-        stroke="#818CF8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.7"/>
+  <!-- Remaining capacity — indigo tick at the far edge -->
+  <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8"/>
 
-  <!-- Terminal dots at arc ends (subtle) -->
-  <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6"/>
-  <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5"/>
-  <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4"/>
+  <!-- Limit indicator dot above the window -->
+  <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7"/>
 </svg>

--- a/assets/logo/logo-white.svg
+++ b/assets/logo/logo-white.svg
@@ -1,34 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" width="320" height="72">
   <!-- White version — no background, all fills/strokes in white with varying opacity -->
 
-  <!-- Mark -->
+  <!-- Mark: context-window frame geometry -->
   <g transform="translate(4, 4)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#FFFFFF"/>
-    <circle cx="14" cy="50" r="5.5" fill="#FFFFFF" opacity="0.12"/>
-
-    <!-- Arc 1 — Live -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#FFFFFF" stroke-width="3" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#FFFFFF" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.65"/>
-
-    <!-- Arc 3 — Report -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#FFFFFF" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.4"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#FFFFFF" opacity="0.5"/>
-    <circle cx="46" cy="14" r="2" fill="#FFFFFF" opacity="0.35"/>
-    <circle cx="56" cy="6" r="2" fill="#FFFFFF" opacity="0.25"/>
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#FFFFFF" stroke-width="2.5" opacity="0.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="#FFFFFF"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#FFFFFF" opacity="0.8"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#FFFFFF" opacity="0.5"/>
+    <circle cx="48" cy="17" r="2.5" fill="#FFFFFF" opacity="0.45"/>
   </g>
 
   <!-- Divider -->
   <line x1="80" y1="16" x2="80" y2="56" stroke="#FFFFFF" stroke-width="1" opacity="0.25"/>
 
-  <!-- Wordmark -->
-  <text x="94" y="38" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#FFFFFF" letter-spacing="-0.5">Context</text>
-  <text x="94" y="58" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="13" font-weight="500" fill="#FFFFFF" letter-spacing="3.5" opacity="0.65">STATS</text>
+  <!-- Wordmark: ContextStats -->
+  <text x="94" y="44" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="24" font-weight="700" fill="#FFFFFF" letter-spacing="-0.5">ContextStats</text>
 </svg>

--- a/assets/logo/logo-wordmark.svg
+++ b/assets/logo/logo-wordmark.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40" width="180" height="40">
   <!-- Wordmark only, transparent background -->
-  <text x="0" y="26" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#F1F5F9" letter-spacing="-0.5">Context</text>
-  <text x="0" y="39" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="11" font-weight="500" fill="#10B981" letter-spacing="3.5">STATS</text>
+  <text x="0" y="28" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="-0.5"><tspan fill="#0F172A">Context</tspan><tspan fill="#10B981">Stats</tspan></text>
 </svg>

--- a/docs/assets/logo/favicon.svg
+++ b/docs/assets/logo/favicon.svg
@@ -2,18 +2,12 @@
   <!-- Background -->
   <rect width="16" height="16" rx="3" fill="#0F172A"/>
 
-  <!-- Simplified three-arc mark at 16×16
-       Origin at (3, 13), arcs sweep to upper-right
-       Keep outer two arcs only for clarity at tiny size -->
+  <!-- Simplified 2-layer context-window mark at 16×16:
+       outer frame + inner fill gauge (drop cursor/tick/dot detail) -->
 
-  <!-- Origin dot -->
-  <circle cx="3" cy="13" r="1" fill="#10B981"/>
+  <!-- Window frame -->
+  <rect x="2.5" y="5" width="11" height="6" rx="2" fill="none" stroke="#334155" stroke-width="1.2"/>
 
-  <!-- Arc 1 — Live (green, innermost) -->
-  <path d="M 3 13 C 3 9, 6 7, 9 7"
-        stroke="#10B981" stroke-width="1" fill="none" stroke-linecap="round"/>
-
-  <!-- Arc 2 — Report (indigo, outer) — skip cyan for clarity -->
-  <path d="M 3 13 C 3 6, 8 2, 14 2"
-        stroke="#818CF8" stroke-width="0.8" fill="none" stroke-linecap="round" opacity="0.75"/>
+  <!-- Fill gauge (green, ~55%) -->
+  <rect x="4" y="6.5" width="5" height="3" rx="1" fill="#10B981"/>
 </svg>

--- a/docs/assets/logo/logo-black.svg
+++ b/docs/assets/logo/logo-black.svg
@@ -1,34 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" width="320" height="72">
   <!-- Black version — no background, for use on light backgrounds -->
 
-  <!-- Mark -->
+  <!-- Mark: context-window frame geometry -->
   <g transform="translate(4, 4)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#0F172A"/>
-    <circle cx="14" cy="50" r="5.5" fill="#0F172A" opacity="0.10"/>
-
-    <!-- Arc 1 — Live -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#0F172A" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.65"/>
-
-    <!-- Arc 3 — Report -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#0F172A" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.4"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#0F172A" opacity="0.5"/>
-    <circle cx="46" cy="14" r="2" fill="#0F172A" opacity="0.35"/>
-    <circle cx="56" cy="6" r="2" fill="#0F172A" opacity="0.25"/>
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#0F172A" stroke-width="2.5" opacity="0.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="#0F172A"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#0F172A" opacity="0.8"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#0F172A" opacity="0.5"/>
+    <circle cx="48" cy="17" r="2.5" fill="#0F172A" opacity="0.45"/>
   </g>
 
   <!-- Divider -->
   <line x1="80" y1="16" x2="80" y2="56" stroke="#0F172A" stroke-width="1" opacity="0.2"/>
 
-  <!-- Wordmark -->
-  <text x="94" y="38" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#0F172A" letter-spacing="-0.5">Context</text>
-  <text x="94" y="58" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="13" font-weight="500" fill="#0F172A" letter-spacing="3.5" opacity="0.6">STATS</text>
+  <!-- Wordmark: ContextStats -->
+  <text x="94" y="44" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="24" font-weight="700" fill="#0F172A" letter-spacing="-0.5">ContextStats</text>
 </svg>

--- a/docs/assets/logo/logo-full.svg
+++ b/docs/assets/logo/logo-full.svg
@@ -1,35 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" width="320" height="72">
+  <defs>
+    <linearGradient id="ctxFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#10B981"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+
   <!-- Background pill -->
   <rect width="320" height="72" rx="14" fill="#0F172A"/>
 
-  <!-- Mark: three-arc analytics symbol, translated to fit 64x64 within 72px height (4px padding each side) -->
+  <!-- Mark: context-window frame, 64x64 within 72px height (4px padding) -->
   <g transform="translate(4, 4)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#10B981"/>
-    <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15"/>
-
-    <!-- Arc 1 — Live (green) -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#10B981" stroke-width="3" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session (cyan) -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#06B6D4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.85"/>
-
-    <!-- Arc 3 — Report (indigo) -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#818CF8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.7"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6"/>
-    <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5"/>
-    <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4"/>
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#ctxFill)"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8"/>
+    <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7"/>
   </g>
 
   <!-- Divider -->
   <line x1="80" y1="16" x2="80" y2="56" stroke="#334155" stroke-width="1" opacity="0.6"/>
 
-  <!-- Wordmark -->
-  <text x="94" y="38" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#F1F5F9" letter-spacing="-0.5">Context</text>
-  <text x="94" y="58" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="13" font-weight="500" fill="#10B981" letter-spacing="3.5">STATS</text>
+  <!-- Wordmark: ContextStats -->
+  <text x="94" y="44" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="24" font-weight="700" letter-spacing="-0.5"><tspan fill="#F1F5F9">Context</tspan><tspan fill="#10B981">Stats</tspan></text>
 </svg>

--- a/docs/assets/logo/logo-icon.svg
+++ b/docs/assets/logo/logo-icon.svg
@@ -1,31 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="ctxFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#10B981"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
+
   <!-- Background: rounded square, deep navy -->
   <rect width="512" height="512" rx="96" fill="#0F172A"/>
 
-  <!-- Mark: canonical three-arc paths scaled ~6.25x, centered in 512×512
-       Base mark origin: (14,50) → translate(86, 137) scale(6.25)
-       So origin maps to: 86 + 14*6.25 = 86+87.5=173.5, 137 + 50*6.25 = 137+312.5=449.5
-       Adjusted translate to keep mark visually centered: translate(70, 90) scale(5.8) -->
-  <g transform="translate(70, 90) scale(5.8)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#10B981"/>
-    <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15"/>
-
-    <!-- Arc 1 — Live (green) -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#10B981" stroke-width="0.52" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session (cyan) -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#06B6D4" stroke-width="0.43" fill="none" stroke-linecap="round" opacity="0.85"/>
-
-    <!-- Arc 3 — Report (indigo) -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#818CF8" stroke-width="0.34" fill="none" stroke-linecap="round" opacity="0.7"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6"/>
-    <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5"/>
-    <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4"/>
+  <!-- Mark: canonical 64x64 geometry scaled 6x, centered.
+       translate(64, 64) scale(6) maps the 64-box to 384px centered in 512 -->
+  <g transform="translate(64, 64) scale(6)">
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#ctxFill)"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8"/>
+    <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7"/>
   </g>
 </svg>

--- a/docs/assets/logo/logo-mark.svg
+++ b/docs/assets/logo/logo-mark.svg
@@ -1,35 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
   <defs>
-    <!-- Three-level palette -->
-    <!-- Arc 1 (live):    #10B981 green  -->
-    <!-- Arc 2 (session): #06B6D4 cyan   -->
-    <!-- Arc 3 (report):  #818CF8 indigo -->
+    <!-- Palette -->
+    <!-- Base:   #0F172A slate    -->
+    <!-- Fill:   #10B981 green (consumed / live)   -->
+    <!-- Cursor: #06B6D4 cyan  (current position)  -->
+    <!-- Edge:   #818CF8 indigo (remaining / limit) -->
+    <linearGradient id="ctxFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#10B981"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
   </defs>
 
-  <!-- Background -->
+  <!-- Background tile -->
   <rect width="64" height="64" rx="14" fill="#0F172A"/>
 
-  <!-- Origin dot — "current moment" cursor -->
-  <circle cx="14" cy="50" r="3" fill="#10B981"/>
-  <circle cx="14" cy="50" r="5.5" fill="#10B981" opacity="0.15"/>
+  <!-- Context window frame (rounded bracket outline) -->
+  <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5"/>
 
-  <!-- Arc 1 — Live (innermost, green) -->
-  <!-- Sweeps from origin upward-right, small radius ~18 -->
-  <path d="M 14 50 C 14 38, 24 28, 36 28"
-        stroke="#10B981" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <!-- Consumed fill gauge (green→cyan), ~58% of inner width -->
+  <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#ctxFill)"/>
 
-  <!-- Arc 2 — Session (middle, cyan) -->
-  <!-- Sweeps from origin upward-right, medium radius ~28 -->
-  <path d="M 14 50 C 14 30, 28 14, 46 14"
-        stroke="#06B6D4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.85"/>
+  <!-- Cursor — current position marker at the fill edge -->
+  <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4"/>
 
-  <!-- Arc 3 — Report (outermost, indigo) -->
-  <!-- Sweeps from origin upward-right, large radius ~38 -->
-  <path d="M 14 50 C 14 22, 34 6, 56 6"
-        stroke="#818CF8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.7"/>
+  <!-- Remaining capacity — indigo tick at the far edge -->
+  <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8"/>
 
-  <!-- Terminal dots at arc ends (subtle) -->
-  <circle cx="36" cy="28" r="2" fill="#10B981" opacity="0.6"/>
-  <circle cx="46" cy="14" r="2" fill="#06B6D4" opacity="0.5"/>
-  <circle cx="56" cy="6" r="2" fill="#818CF8" opacity="0.4"/>
+  <!-- Limit indicator dot above the window -->
+  <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7"/>
 </svg>

--- a/docs/assets/logo/logo-white.svg
+++ b/docs/assets/logo/logo-white.svg
@@ -1,34 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" width="320" height="72">
   <!-- White version — no background, all fills/strokes in white with varying opacity -->
 
-  <!-- Mark -->
+  <!-- Mark: context-window frame geometry -->
   <g transform="translate(4, 4)">
-    <!-- Origin dot -->
-    <circle cx="14" cy="50" r="3" fill="#FFFFFF"/>
-    <circle cx="14" cy="50" r="5.5" fill="#FFFFFF" opacity="0.12"/>
-
-    <!-- Arc 1 — Live -->
-    <path d="M 14 50 C 14 38, 24 28, 36 28"
-          stroke="#FFFFFF" stroke-width="3" fill="none" stroke-linecap="round"/>
-
-    <!-- Arc 2 — Session -->
-    <path d="M 14 50 C 14 30, 28 14, 46 14"
-          stroke="#FFFFFF" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.65"/>
-
-    <!-- Arc 3 — Report -->
-    <path d="M 14 50 C 14 22, 34 6, 56 6"
-          stroke="#FFFFFF" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.4"/>
-
-    <!-- Terminal dots -->
-    <circle cx="36" cy="28" r="2" fill="#FFFFFF" opacity="0.5"/>
-    <circle cx="46" cy="14" r="2" fill="#FFFFFF" opacity="0.35"/>
-    <circle cx="56" cy="6" r="2" fill="#FFFFFF" opacity="0.25"/>
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#FFFFFF" stroke-width="2.5" opacity="0.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="#FFFFFF"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#FFFFFF" opacity="0.8"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#FFFFFF" opacity="0.5"/>
+    <circle cx="48" cy="17" r="2.5" fill="#FFFFFF" opacity="0.45"/>
   </g>
 
   <!-- Divider -->
   <line x1="80" y1="16" x2="80" y2="56" stroke="#FFFFFF" stroke-width="1" opacity="0.25"/>
 
-  <!-- Wordmark -->
-  <text x="94" y="38" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#FFFFFF" letter-spacing="-0.5">Context</text>
-  <text x="94" y="58" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="13" font-weight="500" fill="#FFFFFF" letter-spacing="3.5" opacity="0.65">STATS</text>
+  <!-- Wordmark: ContextStats -->
+  <text x="94" y="44" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="24" font-weight="700" fill="#FFFFFF" letter-spacing="-0.5">ContextStats</text>
 </svg>

--- a/docs/assets/logo/logo-wordmark.svg
+++ b/docs/assets/logo/logo-wordmark.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40" width="180" height="40">
   <!-- Wordmark only, transparent background -->
-  <text x="0" y="26" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="20" font-weight="700" fill="#F1F5F9" letter-spacing="-0.5">Context</text>
-  <text x="0" y="39" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="11" font-weight="500" fill="#10B981" letter-spacing="3.5">STATS</text>
+  <text x="0" y="28" font-family="'Inter', 'SF Pro Display', system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="-0.5"><tspan fill="#0F172A">Context</tspan><tspan fill="#10B981">Stats</tspan></text>
 </svg>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1,0 +1,917 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Documentation — context-stats</title>
+        <meta
+            name="description"
+            content="Full guide to context-stats: the live statusline, per-session export, multi-week reports, the five context zones, Model Intelligence, cache keep-warm, and configuration."
+        />
+        <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large" />
+        <link rel="canonical" href="https://luongnv89.github.io/context-stats/docs.html" />
+
+        <meta property="og:title" content="Documentation — context-stats" />
+        <meta
+            property="og:description"
+            content="The full feature and usage guide for context-stats — live monitoring, session exports, multi-week reports, zones, MI, and config."
+        />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://luongnv89.github.io/context-stats/docs.html" />
+        <meta property="og:image" content="https://luongnv89.github.io/context-stats/images/token-graph.png" />
+
+        <link rel="icon" type="image/svg+xml" href="assets/logo/favicon.svg" />
+        <meta name="theme-color" content="#0F172A" />
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+            rel="stylesheet"
+        />
+
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "TechArticle",
+          "headline": "context-stats Documentation",
+          "description": "Full feature and usage guide for context-stats.",
+          "url": "https://luongnv89.github.io/context-stats/docs.html",
+          "author": { "@type": "Person", "name": "Nguyen Luong" }
+        }
+        </script>
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          "mainEntity": [
+            { "@type": "Question", "name": "Does context-stats send any data to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. All session data stays local in ~/.claude/statusline/. There are no network requests, no telemetry, no external API calls of any kind." } },
+            { "@type": "Question", "name": "Will it slow down my Claude Code sessions?", "acceptedAnswer": { "@type": "Answer", "text": "No. The statusline script runs synchronously on each prompt in under 10ms. Git operations have a 5-second timeout to prevent hangs." } },
+            { "@type": "Question", "name": "Does it work on Windows?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. context-stats is pure Python 3.9+ with zero external dependencies and runs on macOS, Linux, and Windows." } },
+            { "@type": "Question", "name": "What is cache keep-warm and why do I need it?", "acceptedAnswer": { "@type": "Answer", "text": "Claude's prompt cache has a 5-minute TTL. cache-warm runs a lightweight heartbeat every 4 minutes to keep the cache alive for up to 30 minutes." } },
+            { "@type": "Question", "name": "What does the compaction marker mean?", "acceptedAnswer": { "@type": "Answer", "text": "A >50% drop in token count between interactions is detected automatically and marked with a triangle. If MI was below 0.6 at that point, it is flagged as potentially lossy." } }
+          ]
+        }
+        </script>
+
+        <style>
+            *,
+            *::before,
+            *::after {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+            :root {
+                --bg: #0f172a;
+                --bg-deep: #0b1120;
+                --bg-card: #131c30;
+                --bg-subtle: #1c2740;
+                --border: #243049;
+                --border-hover: #334155;
+                --text: #f1f5f9;
+                --text-muted: #94a3b8;
+                --text-dim: #64748b;
+                --green: #10b981;
+                --cyan: #06b6d4;
+                --indigo: #818cf8;
+                --yellow: #f59e0b;
+                --orange: #f97316;
+                --red: #ef4444;
+                --glow: rgba(16, 185, 129, 0.18);
+                --radius: 14px;
+            }
+            html {
+                scroll-behavior: smooth;
+                scroll-padding-top: 80px;
+            }
+            body {
+                font-family: 'Inter', system-ui, -apple-system, sans-serif;
+                background: var(--bg);
+                color: var(--text);
+                line-height: 1.65;
+                -webkit-font-smoothing: antialiased;
+            }
+            a {
+                color: var(--cyan);
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+            code,
+            .mono {
+                font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+            }
+
+            /* Nav */
+            nav {
+                position: sticky;
+                top: 0;
+                z-index: 50;
+                background: rgba(15, 23, 42, 0.85);
+                backdrop-filter: blur(12px);
+                border-bottom: 1px solid var(--border);
+            }
+            .nav-inner {
+                max-width: 1180px;
+                margin: 0 auto;
+                padding: 14px 24px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+            }
+            .nav-logo {
+                display: flex;
+                align-items: center;
+                gap: 11px;
+            }
+            .nav-logo img {
+                height: 34px;
+                display: block;
+            }
+            .nav-wordmark {
+                font-size: 22px;
+                font-weight: 800;
+                letter-spacing: -0.02em;
+                color: var(--text);
+            }
+            .nav-wordmark .stats {
+                color: var(--green);
+            }
+            .nav-links {
+                list-style: none;
+                display: flex;
+                align-items: center;
+                gap: 26px;
+                font-size: 14px;
+                font-weight: 500;
+            }
+            .nav-links a {
+                color: var(--text-muted);
+                text-decoration: none;
+            }
+            .nav-links a:hover {
+                color: var(--text);
+            }
+            .nav-cta {
+                padding: 8px 16px;
+                background: var(--green);
+                color: #04221a !important;
+                border-radius: 8px;
+                font-weight: 700;
+            }
+            @media (max-width: 820px) {
+                .nav-links li.hide-sm {
+                    display: none;
+                }
+            }
+
+            /* Layout: sidebar + content */
+            .layout {
+                max-width: 1180px;
+                margin: 0 auto;
+                padding: 0 24px;
+                display: grid;
+                grid-template-columns: 220px 1fr;
+                gap: 48px;
+                align-items: start;
+            }
+            .sidebar {
+                position: sticky;
+                top: 80px;
+                padding: 40px 0;
+            }
+            .sidebar h4 {
+                font-size: 12px;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                color: var(--text-dim);
+                margin: 20px 0 10px;
+            }
+            .sidebar a {
+                display: block;
+                padding: 5px 0;
+                color: var(--text-muted);
+                font-size: 14px;
+                text-decoration: none;
+                border-left: 2px solid transparent;
+                padding-left: 12px;
+                margin-left: -2px;
+                transition: color 0.15s, border-color 0.15s;
+            }
+            .sidebar a:hover {
+                color: var(--text);
+                border-color: var(--green);
+            }
+            .content {
+                padding: 40px 0 96px;
+                min-width: 0;
+            }
+            @media (max-width: 880px) {
+                .layout {
+                    grid-template-columns: 1fr;
+                    gap: 0;
+                }
+                .sidebar {
+                    display: none;
+                }
+            }
+
+            /* Doc hero */
+            .doc-hero {
+                padding: 56px 0 36px;
+                border-bottom: 1px solid var(--border);
+                margin-bottom: 48px;
+            }
+            .doc-hero .eyebrow {
+                color: var(--green);
+                font-weight: 700;
+                font-size: 13px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+            }
+            .doc-hero h1 {
+                font-size: clamp(2rem, 5vw, 3rem);
+                font-weight: 800;
+                letter-spacing: -0.02em;
+                margin: 12px 0 14px;
+                line-height: 1.1;
+            }
+            .doc-hero p {
+                color: var(--text-muted);
+                font-size: 1.1rem;
+                max-width: 640px;
+            }
+
+            /* Content typography */
+            .content h2 {
+                font-size: 1.7rem;
+                font-weight: 800;
+                letter-spacing: -0.02em;
+                margin: 56px 0 18px;
+                padding-top: 8px;
+            }
+            .content h2:first-of-type {
+                margin-top: 0;
+            }
+            .content h3 {
+                font-size: 1.2rem;
+                font-weight: 700;
+                margin: 32px 0 12px;
+            }
+            .content p {
+                color: var(--text-muted);
+                margin-bottom: 16px;
+            }
+            .content ul {
+                color: var(--text-muted);
+                margin: 0 0 18px 22px;
+            }
+            .content li {
+                margin-bottom: 7px;
+            }
+            .content strong {
+                color: var(--text);
+                font-weight: 600;
+            }
+            .content > section {
+                scroll-margin-top: 80px;
+            }
+            .inline-code {
+                background: var(--bg-subtle);
+                border: 1px solid var(--border);
+                border-radius: 5px;
+                padding: 2px 7px;
+                font-family: 'JetBrains Mono', monospace;
+                font-size: 0.86em;
+                color: var(--cyan);
+            }
+
+            /* Terminal block */
+            .term {
+                background: var(--bg-deep);
+                border: 1px solid var(--border);
+                border-radius: var(--radius);
+                overflow: hidden;
+                margin: 18px 0 26px;
+            }
+            .term-bar {
+                display: flex;
+                gap: 7px;
+                align-items: center;
+                padding: 10px 14px;
+                background: var(--bg-card);
+                border-bottom: 1px solid var(--border);
+            }
+            .term-bar .d {
+                width: 10px;
+                height: 10px;
+                border-radius: 50%;
+            }
+            .d.r {
+                background: #ff5f57;
+            }
+            .d.y {
+                background: #febc2e;
+            }
+            .d.g {
+                background: #28c840;
+            }
+            .term-bar .ttl {
+                margin-left: 8px;
+                font-size: 11.5px;
+                color: var(--text-dim);
+                font-family: 'JetBrains Mono', monospace;
+            }
+            .term pre {
+                padding: 18px 18px;
+                font-family: 'JetBrains Mono', monospace;
+                font-size: 12.5px;
+                line-height: 1.7;
+                overflow-x: auto;
+                color: var(--text-muted);
+            }
+            .g {
+                color: var(--green);
+            }
+            .c {
+                color: var(--cyan);
+            }
+            .i {
+                color: var(--indigo);
+            }
+            .yl {
+                color: var(--yellow);
+            }
+            .or {
+                color: var(--orange);
+            }
+            .rd {
+                color: var(--red);
+            }
+            .dm {
+                color: var(--text-dim);
+            }
+
+            /* Cmd card grid */
+            .cmd-grid {
+                display: grid;
+                grid-template-columns: repeat(2, 1fr);
+                gap: 14px;
+                margin: 20px 0;
+            }
+            .cmd {
+                background: var(--bg-card);
+                border: 1px solid var(--border);
+                border-radius: 10px;
+                padding: 18px;
+            }
+            .cmd code {
+                color: var(--green);
+                font-size: 13px;
+                font-weight: 600;
+            }
+            .cmd p {
+                margin: 8px 0 0;
+                font-size: 13.5px;
+            }
+            @media (max-width: 600px) {
+                .cmd-grid {
+                    grid-template-columns: 1fr;
+                }
+            }
+
+            /* Zones table */
+            .zone-table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 18px 0 26px;
+                font-size: 14px;
+            }
+            .zone-table th,
+            .zone-table td {
+                text-align: left;
+                padding: 12px 14px;
+                border-bottom: 1px solid var(--border);
+            }
+            .zone-table th {
+                color: var(--text-dim);
+                font-weight: 600;
+                font-size: 12px;
+                text-transform: uppercase;
+                letter-spacing: 0.05em;
+            }
+            .zone-table td {
+                color: var(--text-muted);
+            }
+            .zone-table tr td:first-child {
+                font-weight: 700;
+                color: var(--text);
+                white-space: nowrap;
+            }
+            .pill {
+                display: inline-block;
+                width: 10px;
+                height: 10px;
+                border-radius: 50%;
+                margin-right: 8px;
+                vertical-align: middle;
+            }
+
+            /* Callout */
+            .callout {
+                background: var(--bg-card);
+                border: 1px solid var(--border);
+                border-left: 3px solid var(--green);
+                border-radius: 8px;
+                padding: 16px 18px;
+                margin: 22px 0;
+                font-size: 14.5px;
+            }
+            .callout strong {
+                color: var(--green);
+            }
+
+            /* FAQ */
+            details {
+                border: 1px solid var(--border);
+                border-radius: 10px;
+                margin-bottom: 12px;
+                background: var(--bg-card);
+                overflow: hidden;
+            }
+            summary {
+                padding: 16px 20px;
+                cursor: pointer;
+                font-weight: 600;
+                list-style: none;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            }
+            summary::-webkit-details-marker {
+                display: none;
+            }
+            summary::after {
+                content: '+';
+                color: var(--green);
+                font-size: 20px;
+                font-weight: 400;
+            }
+            details[open] summary::after {
+                content: '−';
+            }
+            details p {
+                padding: 0 20px 18px;
+                margin: 0;
+                font-size: 14.5px;
+            }
+
+            /* Reference links grid */
+            .ref-grid {
+                display: grid;
+                grid-template-columns: repeat(3, 1fr);
+                gap: 14px;
+                margin: 18px 0;
+            }
+            .ref {
+                display: block;
+                background: var(--bg-card);
+                border: 1px solid var(--border);
+                border-radius: 10px;
+                padding: 16px;
+                color: var(--text);
+                text-decoration: none;
+                transition: border-color 0.15s;
+            }
+            .ref:hover {
+                border-color: var(--border-hover);
+                text-decoration: none;
+            }
+            .ref strong {
+                display: block;
+                font-size: 14.5px;
+            }
+            .ref span {
+                font-size: 12.5px;
+                color: var(--text-dim);
+            }
+            @media (max-width: 600px) {
+                .ref-grid {
+                    grid-template-columns: 1fr;
+                }
+            }
+
+            /* Footer */
+            footer {
+                border-top: 1px solid var(--border);
+                padding: 36px 0;
+            }
+            .footer-inner {
+                max-width: 1180px;
+                margin: 0 auto;
+                padding: 0 24px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 20px;
+                flex-wrap: wrap;
+                font-size: 14px;
+                color: var(--text-muted);
+            }
+            .footer-inner img {
+                height: 28px;
+                vertical-align: middle;
+                margin-right: 10px;
+            }
+            .footer-inner a {
+                color: var(--green);
+            }
+        </style>
+    </head>
+    <body>
+        <!-- NAV -->
+        <nav>
+            <div class="nav-inner">
+                <a class="nav-logo" href="index.html" aria-label="context-stats home">
+                    <img src="assets/logo/logo-mark.svg" alt="context-stats" />
+                    <span class="nav-wordmark">Context<span class="stats">Stats</span></span>
+                </a>
+                <ul class="nav-links">
+                    <li class="hide-sm"><a href="index.html">Home</a></li>
+                    <li class="hide-sm"><a href="#zones">Zones</a></li>
+                    <li class="hide-sm"><a href="#config">Config</a></li>
+                    <li><a href="https://github.com/luongnv89/context-stats" class="nav-cta">GitHub ★</a></li>
+                </ul>
+            </div>
+        </nav>
+
+        <div class="layout">
+            <!-- SIDEBAR -->
+            <aside class="sidebar">
+                <h4>Getting started</h4>
+                <a href="#install">Install in 60s</a>
+                <a href="#commands">Commands</a>
+                <h4>The three levels</h4>
+                <a href="#live">Level 1 · Live</a>
+                <a href="#session">Level 2 · Session</a>
+                <a href="#report">Level 3 · Report</a>
+                <h4>Concepts</h4>
+                <a href="#zones">Context zones</a>
+                <a href="#mi">Model Intelligence</a>
+                <a href="#cache">Cache keep-warm</a>
+                <a href="#compaction">Compaction</a>
+                <h4>Reference</h4>
+                <a href="#config">Configuration</a>
+                <a href="#faq">FAQ</a>
+                <a href="#more">More docs</a>
+            </aside>
+
+            <!-- CONTENT -->
+            <main class="content">
+                <div class="doc-hero">
+                    <span class="eyebrow">Documentation</span>
+                    <h1>Everything context-stats does, in detail.</h1>
+                    <p>
+                        A real-time view of your Claude Code context window, plus the session and
+                        multi-week analytics that tell you where your tokens actually go. No
+                        network calls — everything stays local.
+                    </p>
+                </div>
+
+                <!-- INSTALL -->
+                <section id="install">
+                    <h2>Install in 60 seconds</h2>
+                    <p>Pure Python 3.9+, zero external dependencies. macOS, Linux, and Windows.</p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">terminal</span></div>
+                        <pre><span class="g">$</span> pip install context-stats
+<span class="dm">Successfully installed context-stats-1.22.0</span></pre>
+                    </div>
+                    <p>Then add the statusline to <span class="inline-code">~/.claude/settings.json</span>:</p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">~/.claude/settings.json</span></div>
+                        <pre>{
+  <span class="c">"statusLine"</span>: {
+    <span class="c">"type"</span>: <span class="g">"command"</span>,
+    <span class="c">"command"</span>: <span class="g">"claude-statusline"</span>
+  }
+}</pre>
+                    </div>
+                    <p>
+                        Start (or restart) Claude Code — your statusline is now live with context
+                        zone, Model Intelligence, and token delta on every prompt.
+                    </p>
+                </section>
+
+                <!-- COMMANDS -->
+                <section id="commands">
+                    <h2>The commands</h2>
+                    <p>Run any of these any time — no session ID needed.</p>
+                    <div class="cmd-grid">
+                        <div class="cmd"><code>context-stats graph</code><p>Live ASCII dashboard — context, MI, cache, and delta per interaction.</p></div>
+                        <div class="cmd"><code>context-stats sessions</code><p>List recent sessions (last 5 minutes by default; <span class="inline-code">--minutes N</span> to widen).</p></div>
+                        <div class="cmd"><code>context-stats export</code><p>Export a full session report to Markdown — cache, timeline, zones.</p></div>
+                        <div class="cmd"><code>context-stats report</code><p>Multi-project cost analytics (<span class="inline-code">--since-days 30</span>).</p></div>
+                        <div class="cmd"><code>context-stats &lt;id&gt; cache-warm on</code><p>Keep the prompt cache alive during idle gaps (heartbeat every 4 min).</p></div>
+                        <div class="cmd"><code>context-stats explain</code><p>Explain the raw JSON Claude Code pipes to the statusline.</p></div>
+                    </div>
+                </section>
+
+                <!-- LEVEL 1 -->
+                <section id="live">
+                    <h2>Level 1 — Live stats</h2>
+                    <p>
+                        The always-on statusline shows you, at a glance, the model, branch, and how
+                        much context window remains. Run <span class="inline-code">context-stats graph</span>
+                        any time to expand that into a full history.
+                    </p>
+                    <h3>The statusline</h3>
+                    <p>A single line rendered by Claude Code on every prompt:</p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">Claude Code statusline</span></div>
+                        <pre><span class="g">meta-app</span><span class="dm"> | </span><span class="c">feat/85-catalog-visibility-toggle</span> <span class="c">[3]</span><span class="dm"> | </span><span class="yl">132,944 (66.5%)</span><span class="dm"> | </span><span class="dm">Code | 3.3 tok/s | Sonnet 4.6 | baaff3c8-2b25-458b-adcd-96ebdeb5125d</span></pre>
+                    </div>
+                    <p>Each <span class="inline-code">|</span>-separated segment, left to right:</p>
+                    <ul>
+                        <li><strong>meta-app</strong> — current project directory.</li>
+                        <li><strong>feat/85-… [3]</strong> — git branch and uncommitted change count.</li>
+                        <li><strong>132,944 (66.5%)</strong> — remaining context window, colored by zone.</li>
+                        <li><strong>Code</strong> — current context zone.</li>
+                        <li><strong>3.3 tok/s</strong> — rolling model throughput over the last 5 turns.</li>
+                        <li><strong>Sonnet 4.6</strong> — active model.</li>
+                        <li><strong>baaff3c8-…</strong> — session ID.</li>
+                    </ul>
+                    <p style="font-size: 13.5px; color: var(--text-dim)">
+                        Every segment is configurable via <span class="inline-code">~/.claude/statusline.conf</span>.
+                        Optional extras — the MI score (<span class="inline-code">show_mi</span>), token delta
+                        (<span class="inline-code">show_delta</span>), and open PR number (<span class="inline-code">show_pr</span>) —
+                        slot in when enabled.
+                    </p>
+
+                    <h3>The graph dashboard</h3>
+                    <p>An on-demand ASCII view of cumulative usage, per-interval delta, and summary stats:</p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">context-stats graph</span></div>
+                        <pre><span class="g">$</span> context-stats graph
+
+<span class="dm">Token Usage Graphs (Session: a3f9c12d…)</span>
+
+<span class="dm">Cumulative Token Usage          Max: 53,250  Min: 25,148</span>
+<span class="g">53,250 ┤              ▄▄▟████████</span>
+<span class="g">37,192 ┤          ▗▄███████████</span>
+<span class="g">25,148 ┤▄▄▄▄▄▟████</span>
+<span class="dm">       └─16:25───────16:27───────16:34</span>
+
+<span class="dm">Token Delta Per Interval        Max: 25,148  Min: 0</span>
+<span class="c">25,148 ┤▌          ▖      ▟</span>
+<span class="c">10,778 ┤▌    ▖     █   ▖  █</span>
+<span class="c">     0 ┤█▁▁▁▂▂▁▁▁▁██▁▁▁███▁</span>
+<span class="dm">       └─16:25───────16:27───────16:34</span>
+
+<span class="dm">Summary Statistics</span>
+<span class="dm">Current Tokens:   </span><span class="g">53,250</span>
+<span class="dm">Session Duration: </span>8m
+<span class="dm">Data Points:      </span>18
+<span class="dm">Average Delta:    </span><span class="c">2,958</span>
+<span class="dm">Max Delta:        </span><span class="c">25,148</span>
+<span class="dm">Total Growth:     </span><span class="g">28,102</span></pre>
+                    </div>
+                </section>
+
+                <!-- LEVEL 2 -->
+                <section id="session">
+                    <h2>Level 2 — Session deep dive</h2>
+                    <p>
+                        <span class="inline-code">context-stats export</span> writes a full
+                        Markdown report for a single session — summary, key takeaways, an
+                        interaction timeline (with MI and zone per step), context growth, and cache
+                        statistics — then prints a short confirmation:
+                    </p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">context-stats export</span></div>
+                        <pre><span class="g">$</span> context-stats export --output report.md
+
+<span class="g">Exported to report.md</span>
+<span class="dm">  Session:      </span>a3f9c12d-98e0-4a40-8150-690985da46d4
+<span class="dm">  Interactions: </span>38
+<span class="dm">  Model:        </span>claude-opus-4-5-20251101</pre>
+                    </div>
+                    <p>The generated <span class="inline-code">report.md</span> opens with a summary table:</p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">report.md — ## Summary</span></div>
+                        <pre><span class="dm">| Metric             | Value              |</span>
+<span class="dm">|--------------------|--------------------|</span>
+| Context window     | <span class="c">200,000 tokens</span>
+| Final usage        | <span class="yl">168,400 (84.2%)</span>
+| Total input tokens | 812,340
+| Total output tokens| 793,218
+| Session cost       | <span class="g">$51.7475</span>
+| Lines changed      | <span class="g">+1,123</span> / <span class="rd">-887</span>
+| Final MI score     | <span class="or">0.412 (Dump zone)</span></pre>
+                    </div>
+                </section>
+
+                <!-- LEVEL 3 -->
+                <section id="report">
+                    <h2>Level 3 — Multi-week report</h2>
+                    <p>
+                        <span class="inline-code">context-stats report --since-days 30</span>
+                        aggregates across every session and project into a Markdown analytics
+                        report: an executive summary, per-model cost breakdown, and the top cost
+                        drivers. Here's a sample over 30 days:
+                    </p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">report.md — Executive Summary</span></div>
+                        <pre><span class="dm"># Token Usage Analytics Report</span>
+<span class="dm">Generated with: context-stats report --since-days 30</span>
+
+<span class="dm">| Metric             | Value     |</span>
+| Total Spend        | <span class="g">$1,842.35</span>
+| Total Sessions     | 312
+| Projects Analyzed  | 18
+| Cache Hit Ratio    | <span class="yl">41.2%</span>
+| Avg Session Cost   | <span class="g">$5.90</span>
+| Avg Session Duration | 3h 22m
+
+<span class="dm">## Model Usage Breakdown</span>
+<span class="dm">| Model  | Sessions | Tokens      | Cost      | %     |</span>
+| <span class="c">opus</span>   | 241      | 38,204,512  | <span class="g">$1512.30</span>  | 82.1% |
+| <span class="c">sonnet</span> | 42       |  5,918,340  | <span class="g">$ 218.75</span>  | 11.9% |
+| <span class="c">haiku</span>  | 29       |  5,102,876  | <span class="g">$ 111.30</span>  |  6.0% |
+
+<span class="dm">### Top Cost Driver</span>
+a3f9c12d… · <span class="c">project-alpha</span> · <span class="g">$87.40</span> · cache <span class="yl">5%</span> · 2h 14m</pre>
+                    </div>
+                    <p class="dm" style="font-size: 13px; color: var(--text-dim)">
+                        Project names and session IDs are anonymized in the sample. See the
+                        <a href="example-report-30days.md">full example report</a>.
+                    </p>
+                </section>
+
+                <!-- ZONES -->
+                <section id="zones">
+                    <h2>The five context zones</h2>
+                    <p>
+                        As your context fills, context-stats classifies the session into one of
+                        five zones — each with a single, clear action.
+                    </p>
+                    <table class="zone-table">
+                        <thead>
+                            <tr><th>Zone</th><th>What it means</th><th>Recommendation</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td><span class="pill" style="background:var(--green)"></span>Planning</td><td>Plenty of room. Model at full strength.</td><td>Safe to plan and code.</td></tr>
+                            <tr><td><span class="pill" style="background:var(--yellow)"></span>Code-only</td><td>Comfortable working range.</td><td>Avoid starting new tasks; finish the current one.</td></tr>
+                            <tr><td><span class="pill" style="background:var(--orange)"></span>Dump zone</td><td>Getting full; quality starts to slip.</td><td>Consider <span class="inline-code">/compact focus on X</span> or delegate to a subagent.</td></tr>
+                            <tr><td><span class="pill" style="background:var(--red)"></span>Hard limit</td><td>Very full; high risk of degradation.</td><td>Run <span class="inline-code">/compact</span> now before quality degrades further.</td></tr>
+                            <tr><td><span class="pill" style="background:#64748b"></span>Dead zone</td><td>Window essentially exhausted.</td><td>Start a new session with <span class="inline-code">/clear</span>.</td></tr>
+                        </tbody>
+                    </table>
+                    <p style="font-size: 13.5px; color: var(--text-dim)">
+                        Zone names map to the internal keys <span class="inline-code">Plan</span>,
+                        <span class="inline-code">Code</span>, <span class="inline-code">Dump</span>,
+                        <span class="inline-code">ExDump</span>, and <span class="inline-code">Dead</span>.
+                    </p>
+                </section>
+
+                <!-- MI -->
+                <section id="mi">
+                    <h2>Model Intelligence (MI)</h2>
+                    <p>
+                        MI is a single 0–1 score estimating how well the model can still reason
+                        given how full the context is. It's calibrated against the
+                        <strong>MRCR v2 8-needle benchmark</strong>, using the formula
+                        <span class="inline-code">MI = max(0, 1 − u<sup>β</sup>)</span> where
+                        <span class="inline-code">u</span> is context utilization and
+                        <span class="inline-code">β</span> is a model-specific degradation curve
+                        (higher β = quality retained longer).
+                    </p>
+                    <ul>
+                        <li><strong>≥ 0.90</strong> — green: full reasoning quality.</li>
+                        <li><strong>0.80–0.90</strong> — yellow: still solid; watch long chains.</li>
+                        <li><strong>below 0.80</strong> — degrading; compaction below 0.60 is flagged lossy.</li>
+                    </ul>
+                </section>
+
+                <!-- CACHE -->
+                <section id="cache">
+                    <h2>Cache keep-warm</h2>
+                    <p>
+                        Claude's prompt cache has a <strong>5-minute TTL</strong>. Any pause longer
+                        than that silently evicts the cache — and your next prompt pays full price
+                        to rebuild it.
+                    </p>
+                    <div class="callout">
+                        <strong>cache-warm</strong> runs a lightweight background heartbeat every
+                        4 minutes, keeping the cache alive for up to 30 minutes. The savings show
+                        up directly in your <span class="inline-code">context-stats export</span> report.
+                    </div>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">cache keep-warm</span></div>
+                        <pre><span class="g">$</span> context-stats &lt;session_id&gt; cache-warm on
+
+<span class="g">Cache-warm activated for session a3f9c12d….</span>
+<span class="dm">Heartbeat every 4 minutes, auto-stops in 30m.</span></pre>
+                    </div>
+                </section>
+
+                <!-- COMPACTION -->
+                <section id="compaction">
+                    <h2>Compaction detection</h2>
+                    <p>
+                        When Claude Code compacts its context — a <strong>&gt;50% drop</strong> in
+                        token count between interactions — context-stats detects it automatically
+                        and marks the point with a <span class="inline-code">▼</span> symbol. If MI
+                        was below 0.6 at that moment, the event is flagged as
+                        <strong>potentially lossy</strong>: key details may have been dropped from
+                        the summary, and you should verify anything important survived.
+                    </p>
+                </section>
+
+                <!-- CONFIG -->
+                <section id="config">
+                    <h2>Configuration</h2>
+                    <p>
+                        Create <span class="inline-code">~/.claude/statusline.conf</span> with
+                        simple <span class="inline-code">key=value</span> pairs. Customize 18 named
+                        colors (or hex codes), toggle MI display, token detail, delta tracking,
+                        session ID, motion effects, tok/s, and more.
+                    </p>
+                    <div class="term">
+                        <div class="term-bar"><span class="d r"></span><span class="d y"></span><span class="d g"></span><span class="ttl">~/.claude/statusline.conf</span></div>
+                        <pre><span class="dm"># Display toggles</span>
+show_mi=<span class="g">true</span>
+show_delta=<span class="g">true</span>
+show_tps=<span class="g">true</span>
+show_session_id=<span class="g">false</span>
+
+<span class="dm"># Colors (named or #hex)</span>
+color_zone_code=<span class="yl">yellow</span>
+color_mi_high=<span class="g">#10B981</span></pre>
+                    </div>
+                    <p>See the full reference in the <a href="configuration.md">configuration docs</a>.</p>
+                </section>
+
+                <!-- FAQ -->
+                <section id="faq">
+                    <h2>FAQ</h2>
+                    <details>
+                        <summary>Does context-stats send any data to the cloud?</summary>
+                        <p>No. All session data stays local in <span class="inline-code">~/.claude/statusline/</span>. There are no network requests, no telemetry, and no external API calls of any kind. Your token usage and session data never leave your machine.</p>
+                    </details>
+                    <details>
+                        <summary>Will it slow down my Claude Code sessions?</summary>
+                        <p>No. The statusline script is a lightweight Python process that runs synchronously on each prompt, reading local CSV and writing a single line. Typical execution is under 10ms; git operations have a 5-second timeout to prevent hangs.</p>
+                    </details>
+                    <details>
+                        <summary>Does it work on Windows?</summary>
+                        <p>Yes. context-stats is pure Python 3.9+ with zero external dependencies and runs on macOS, Linux, and Windows.</p>
+                    </details>
+                    <details>
+                        <summary>How accurate are the token counts?</summary>
+                        <p>context-stats reads token data directly from Claude Code's statusline JSON and reports the exact values Claude Code provides. The MI score is calibrated against the MRCR v2 8-needle benchmark.</p>
+                    </details>
+                    <details>
+                        <summary>What's the difference between the statusline and the graph dashboard?</summary>
+                        <p>The statusline (<span class="inline-code">claude-statusline</span>) is the always-on one-line display Claude Code shows at each prompt. The graph dashboard (<span class="inline-code">context-stats graph</span>) is an on-demand ASCII view you run manually to see usage history, MI trends, cache activity, and delta per interaction.</p>
+                    </details>
+                    <details>
+                        <summary>Can I customize the colors and display?</summary>
+                        <p>Yes. Create <span class="inline-code">~/.claude/statusline.conf</span> with key=value pairs to customize colors, toggle MI/delta/session ID/tok-s, and more. See the configuration section above.</p>
+                    </details>
+                </section>
+
+                <!-- MORE DOCS -->
+                <section id="more">
+                    <h2>Deeper reference</h2>
+                    <p>For internals and contribution, see the source-controlled docs:</p>
+                    <div class="ref-grid">
+                        <a class="ref" href="installation.md"><strong>Installation</strong><span>Setup & platforms</span></a>
+                        <a class="ref" href="configuration.md"><strong>Configuration</strong><span>Every conf key</span></a>
+                        <a class="ref" href="MODEL_INTELLIGENCE.md"><strong>Model Intelligence</strong><span>The MI formula</span></a>
+                        <a class="ref" href="ARCHITECTURE.md"><strong>Architecture</strong><span>Data flow</span></a>
+                        <a class="ref" href="CSV_FORMAT.md"><strong>CSV format</strong><span>State file fields</span></a>
+                        <a class="ref" href="troubleshooting.md"><strong>Troubleshooting</strong><span>Common issues</span></a>
+                    </div>
+                </section>
+            </main>
+        </div>
+
+        <!-- FOOTER -->
+        <footer>
+            <div class="footer-inner">
+                <div>
+                    <img src="assets/logo/logo-mark.svg" alt="context-stats" />context-stats · MIT
+                    License · Made by <a href="https://github.com/luongnv89">luongnv89</a>
+                </div>
+                <div>
+                    <a href="index.html">Home</a> ·
+                    <a href="https://pypi.org/project/context-stats/">PyPI</a> ·
+                    <a href="https://github.com/luongnv89/context-stats">GitHub</a>
+                </div>
+            </div>
+        </footer>
+    </body>
+</html>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -704,12 +704,12 @@
                         <pre><span class="dm">| Metric             | Value              |</span>
 <span class="dm">|--------------------|--------------------|</span>
 | Context window     | <span class="c">200,000 tokens</span>
-| Final usage        | <span class="yl">168,400 (84.2%)</span>
+| Final usage        | <span class="or">124,800 (62.4%)</span>
 | Total input tokens | 812,340
 | Total output tokens| 793,218
 | Session cost       | <span class="g">$51.7475</span>
 | Lines changed      | <span class="g">+1,123</span> / <span class="rd">-887</span>
-| Final MI score     | <span class="or">0.412 (Dump zone)</span></pre>
+| Final MI score     | <span class="or">0.572 (Dump zone)</span></pre>
                     </div>
                 </section>
 
@@ -790,8 +790,8 @@ a3f9c12d… · <span class="c">project-alpha</span> · <span class="g">$87.40</s
                     </p>
                     <ul>
                         <li><strong>≥ 0.90</strong> — green: full reasoning quality.</li>
-                        <li><strong>0.80–0.90</strong> — yellow: still solid; watch long chains.</li>
-                        <li><strong>below 0.80</strong> — degrading; compaction below 0.60 is flagged lossy.</li>
+                        <li><strong>0.80 &lt; MI &lt; 0.90</strong> — yellow: still solid; watch long chains.</li>
+                        <li><strong>≤ 0.80</strong> — degrading; compaction below 0.60 is flagged lossy.</li>
                     </ul>
                 </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,10 +16,7 @@
         <link rel="canonical" href="https://luongnv89.github.io/context-stats/" />
 
         <!-- Open Graph -->
-        <meta
-            property="og:title"
-            content="context-stats — Track Claude Code Token Usage"
-        />
+        <meta property="og:title" content="context-stats — Track Claude Code Token Usage" />
         <meta
             property="og:description"
             content="Know your context zone. Act before Claude degrades. Free, zero-dependency Python tool."
@@ -39,11 +36,17 @@
         <!-- Favicon -->
         <link rel="icon" type="image/svg+xml" href="assets/logo/favicon.svg" />
         <link rel="apple-touch-icon" href="assets/logo/logo-full.svg" />
-        <meta name="theme-color" content="#0a0a0a" />
+        <meta name="theme-color" content="#0F172A" />
 
         <!-- Resource hints -->
         <link rel="preconnect" href="https://api.github.com" />
         <link rel="preconnect" href="https://pypistats.org" crossorigin />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+            rel="stylesheet"
+        />
 
         <!-- JSON-LD Structured Data -->
         <script type="application/ld+json">
@@ -97,94 +100,6 @@
           "description": "Real-time context window monitoring for Claude Code sessions."
         }
         </script>
-        <script type="application/ld+json">
-        {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          "mainEntity": [
-            {
-              "@type": "Question",
-              "name": "Does context-stats send any data to the cloud?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "No. All session data stays local in ~/.claude/statusline/. There are no network requests, no telemetry, no external API calls of any kind. Your token usage and session data never leave your machine."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Will it slow down my Claude Code sessions?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "No. The statusline script is a lightweight Python process that runs synchronously on each prompt. Typical execution is under 10ms. Git operations have a 5-second timeout to prevent hangs."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Does it work on Windows?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Yes. context-stats is pure Python 3.9+ with zero external dependencies and runs on macOS, Linux, and Windows."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "What Python version do I need?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Python 3.9 or higher. No external packages are required — context-stats uses only the Python standard library."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "Can I customize the colors and display?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Yes. Create ~/.claude/statusline.conf with key=value pairs. You can customize 18 named colors or use hex codes, toggle MI display, token detail, delta tracking, session ID, motion effects, and more."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "How accurate are the token counts?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "context-stats reads the token data directly from Claude Code's status line JSON. It reports the exact values that Claude Code provides. The MI score is calibrated against the MRCR v2 8-needle benchmark."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "What's the difference between the statusline and the graph dashboard?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "The statusline (claude-statusline) is the persistent one-line display shown by Claude Code at each prompt — always on. The graph dashboard (context-stats graph) is an on-demand ASCII chart view you run manually to see usage history, MI trends, cache activity, and delta per interaction."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "What is cache keep-warm and why do I need it?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Claude's prompt cache has a 5-minute TTL. Any pause longer than 5 minutes silently evicts the cache. cache-warm solves this by running a lightweight background heartbeat every 4 minutes, keeping the cache alive for up to 30 minutes. The savings show up in your context-stats export report."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "What is compaction detection and what does the ▼ marker mean?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "When Claude Code compacts its context (a >50% drop in token count between interactions), context-stats detects it automatically and marks the point with a ▼ symbol. If MI was below 0.6 when compaction happened, it flags the event as potentially lossy — meaning key details may have been lost in the summary."
-              }
-            },
-            {
-              "@type": "Question",
-              "name": "What are zone recommendations?",
-              "acceptedAnswer": {
-                "@type": "Answer",
-                "text": "Each context zone (Planning, Code, Dump, ExDump, Dead) comes with a brief actionable recommendation. For example, in the Dump zone you'll see \"Wrap up task, export session, prepare new context\". These appear inline in the statusline output and in graph annotations."
-              }
-            }
-          ]
-        }
-        </script>
 
         <style>
             /* ── Reset & Base ──────────────────────────────────── */
@@ -196,30 +111,27 @@
                 padding: 0;
             }
 
-            /* ── Dark theme — luongnv.com palette ──────────────── */
+            /* ── Brand theme — context-stats logo palette ─────── */
             :root {
-                --bg: #0a0a0a;
-                --bg-card: #111111;
-                --bg-subtle: #1a1a1a;
-                --border: #262626;
-                --border-hover: #404040;
-                --text: #fafafa;
-                --text-muted: #a1a1a1;
-                --accent: #00ff41;
-                --accent-hover: #00cc33;
-                --accent-glow: rgba(0, 255, 65, 0.15);
+                --bg: #0f172a;
+                --bg-deep: #0b1120;
+                --bg-card: #131c30;
+                --bg-subtle: #1c2740;
+                --border: #243049;
+                --border-hover: #334155;
+                --text: #f1f5f9;
+                --text-muted: #94a3b8;
+                --text-dim: #64748b;
 
-                --green: #00ff41;
+                --green: #10b981;
                 --cyan: #06b6d4;
                 --indigo: #818cf8;
                 --yellow: #f59e0b;
-                --orange: #f97316;
                 --red: #ef4444;
-                --gray: #64748b;
 
-                --radius: 12px;
-                --radius-lg: 20px;
-                --shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+                --glow: rgba(16, 185, 129, 0.18);
+                --radius: 14px;
+                --maxw: 1080px;
             }
 
             html {
@@ -227,311 +139,259 @@
             }
 
             body {
+                font-family: 'Inter', system-ui, -apple-system, sans-serif;
                 background: var(--bg);
                 color: var(--text);
-                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-                font-size: 16px;
                 line-height: 1.6;
+                -webkit-font-smoothing: antialiased;
                 overflow-x: hidden;
             }
 
-            a {
-                color: var(--cyan);
-                text-decoration: none;
-            }
-            a:hover {
-                text-decoration: underline;
-            }
-
-            /* ── Layout helpers ────────────────────────────────── */
             .container {
-                max-width: 1100px;
+                max-width: var(--maxw);
                 margin: 0 auto;
                 padding: 0 24px;
             }
 
-            section {
-                padding: 80px 0;
-            }
-
-            .section-label {
-                display: inline-block;
-                font-size: 12px;
-                font-weight: 700;
-                letter-spacing: 0.12em;
-                text-transform: uppercase;
-                color: var(--cyan);
-                margin-bottom: 12px;
-            }
-
-            h2 {
-                font-size: clamp(28px, 4vw, 40px);
-                font-weight: 700;
-                line-height: 1.2;
-                margin-bottom: 16px;
-            }
-
-            .lead {
-                font-size: 18px;
-                color: var(--text-muted);
-                max-width: 600px;
-                margin-bottom: 40px;
-            }
-
-            /* ── NAV ───────────────────────────────────────────── */
-            nav {
-                position: sticky;
-                top: 0;
-                z-index: 100;
-                background: rgba(10, 10, 10, 0.92);
-                backdrop-filter: blur(12px);
-                border-bottom: 1px solid var(--border);
-            }
-
-            .nav-inner {
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-                padding: 14px 24px;
-                max-width: 1100px;
-                margin: 0 auto;
-            }
-
-            .nav-logo {
-                display: flex;
-                align-items: center;
-                gap: 10px;
-            }
-            .nav-logo img {
-                height: 36px;
-            }
-            .nav-logo span {
-                font-size: 15px;
-                font-weight: 600;
-                color: var(--text);
-                letter-spacing: -0.02em;
-            }
-
-            .nav-links {
-                display: flex;
-                gap: 28px;
-                list-style: none;
-            }
-            .nav-links a {
-                font-size: 14px;
-                font-weight: 500;
-                color: var(--text-muted);
-                transition: color 0.2s;
-            }
-            .nav-links a:hover {
-                color: var(--text);
+            a {
+                color: inherit;
                 text-decoration: none;
             }
 
+            code,
+            .mono {
+                font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+            }
+
+            /* ── Nav ───────────────────────────────────────────── */
+            nav {
+                position: sticky;
+                top: 0;
+                z-index: 50;
+                background: rgba(15, 23, 42, 0.82);
+                backdrop-filter: blur(12px);
+                border-bottom: 1px solid var(--border);
+            }
+            .nav-inner {
+                max-width: var(--maxw);
+                margin: 0 auto;
+                padding: 14px 24px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+            }
+            .nav-logo {
+                display: flex;
+                align-items: center;
+                gap: 11px;
+            }
+            .nav-logo img {
+                height: 34px;
+                display: block;
+            }
+            .nav-wordmark {
+                font-size: 22px;
+                font-weight: 800;
+                letter-spacing: -0.02em;
+                color: var(--text);
+            }
+            .nav-wordmark .stats {
+                color: var(--green);
+            }
+            .nav-links {
+                list-style: none;
+                display: flex;
+                align-items: center;
+                gap: 28px;
+                font-size: 14px;
+                font-weight: 500;
+            }
+            .nav-links a {
+                color: var(--text-muted);
+                transition: color 0.15s;
+            }
+            .nav-links a:hover {
+                color: var(--text);
+            }
             .nav-cta {
+                padding: 8px 16px;
                 background: var(--green);
-                color: var(--bg) !important;
-                padding: 8px 18px;
+                color: #04221a !important;
                 border-radius: 8px;
-                font-weight: 700 !important;
-                font-size: 13px !important;
-                transition: opacity 0.2s !important;
+                font-weight: 700;
             }
             .nav-cta:hover {
-                opacity: 0.85;
-                text-decoration: none !important;
+                background: #34d399;
+            }
+            @media (max-width: 720px) {
+                .nav-links li:not(:last-child) {
+                    display: none;
+                }
             }
 
-            /* ── HERO ──────────────────────────────────────────── */
+            /* ── Buttons ───────────────────────────────────────── */
+            .btn-primary,
+            .btn-secondary {
+                display: inline-flex;
+                align-items: center;
+                gap: 8px;
+                padding: 13px 24px;
+                border-radius: 10px;
+                font-weight: 700;
+                font-size: 15px;
+                transition: all 0.18s;
+                cursor: pointer;
+            }
+            .btn-primary {
+                background: var(--green);
+                color: #04221a;
+                box-shadow: 0 8px 30px var(--glow);
+            }
+            .btn-primary:hover {
+                background: #34d399;
+                transform: translateY(-1px);
+            }
+            .btn-secondary {
+                background: var(--bg-card);
+                color: var(--text);
+                border: 1px solid var(--border);
+            }
+            .btn-secondary:hover {
+                border-color: var(--border-hover);
+                background: var(--bg-subtle);
+            }
+
+            /* ── Hero ──────────────────────────────────────────── */
             .hero {
-                padding: 100px 0 80px;
-                text-align: center;
                 position: relative;
-                overflow: hidden;
+                padding: 96px 0 64px;
+                text-align: center;
             }
-
             .hero::before {
                 content: '';
                 position: absolute;
-                top: -200px;
+                top: -10%;
                 left: 50%;
                 transform: translateX(-50%);
-                width: 800px;
-                height: 600px;
-                background: radial-gradient(ellipse, rgba(16, 185, 129, 0.08) 0%, transparent 70%);
+                width: 760px;
+                height: 460px;
+                background: radial-gradient(
+                    ellipse at center,
+                    var(--glow),
+                    transparent 68%
+                );
+                z-index: -1;
                 pointer-events: none;
             }
-
             .hero-badge {
                 display: inline-flex;
                 align-items: center;
-                gap: 6px;
-                background: rgba(16, 185, 129, 0.1);
-                border: 1px solid rgba(16, 185, 129, 0.25);
-                border-radius: 999px;
+                gap: 8px;
                 padding: 6px 14px;
+                background: var(--bg-card);
+                border: 1px solid var(--border);
+                border-radius: 100px;
                 font-size: 13px;
-                color: var(--green);
+                font-weight: 500;
+                color: var(--text-muted);
                 margin-bottom: 28px;
             }
             .hero-badge .dot {
-                width: 6px;
-                height: 6px;
+                width: 7px;
+                height: 7px;
                 border-radius: 50%;
                 background: var(--green);
-                animation: pulse 2s infinite;
+                box-shadow: 0 0 8px var(--green);
             }
-            @keyframes pulse {
-                0%,
-                100% {
-                    opacity: 1;
-                    transform: scale(1);
-                }
-                50% {
-                    opacity: 0.5;
-                    transform: scale(0.8);
-                }
-            }
-
             .hero h1 {
-                font-size: clamp(36px, 6vw, 64px);
+                font-size: clamp(2.4rem, 6vw, 4rem);
                 font-weight: 800;
-                line-height: 1.1;
+                line-height: 1.08;
                 letter-spacing: -0.03em;
-                margin-bottom: 20px;
+                margin-bottom: 22px;
             }
-
-            .hero h1 .accent-green {
+            .accent-green {
                 color: var(--green);
             }
-            .hero h1 .accent-cyan {
+            .accent-cyan {
                 color: var(--cyan);
             }
-            .hero h1 .accent-indigo {
-                color: var(--indigo);
-            }
-
             .hero-sub {
-                font-size: clamp(16px, 2.5vw, 20px);
+                font-size: clamp(1.05rem, 2vw, 1.25rem);
                 color: var(--text-muted);
-                max-width: 560px;
-                margin: 0 auto 40px;
+                max-width: 600px;
+                margin: 0 auto 36px;
             }
-
             .hero-actions {
                 display: flex;
                 gap: 14px;
                 justify-content: center;
                 flex-wrap: wrap;
-                margin-bottom: 56px;
             }
 
-            .btn-primary {
-                display: inline-flex;
-                align-items: center;
-                gap: 8px;
-                background: var(--green);
-                color: var(--bg);
-                padding: 14px 28px;
-                border-radius: 10px;
-                font-weight: 700;
-                font-size: 15px;
-                transition:
-                    transform 0.15s,
-                    box-shadow 0.15s;
-                box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4);
-            }
-            .btn-primary:hover {
-                transform: translateY(-2px);
-                box-shadow: 0 8px 24px rgba(16, 185, 129, 0.3);
-                text-decoration: none;
-            }
-
-            .btn-secondary {
-                display: inline-flex;
-                align-items: center;
-                gap: 8px;
-                background: transparent;
-                color: var(--text);
-                padding: 14px 28px;
-                border-radius: 10px;
-                font-weight: 600;
-                font-size: 15px;
-                border: 1px solid var(--border);
-                transition:
-                    border-color 0.2s,
-                    background 0.2s;
-            }
-            .btn-secondary:hover {
-                border-color: var(--cyan);
-                background: rgba(6, 182, 212, 0.05);
-                text-decoration: none;
-            }
-
-            /* ── Terminal demo ─────────────────────────────────── */
+            /* ── Terminal ──────────────────────────────────────── */
             .terminal-wrap {
-                max-width: 820px;
-                margin: 0 auto;
+                max-width: 680px;
+                margin: 56px auto 0;
+                perspective: 1400px;
             }
-
             .terminal {
-                background: var(--bg-subtle);
+                background: var(--bg-deep);
                 border: 1px solid var(--border);
-                border-radius: var(--radius-lg);
+                border-radius: var(--radius);
+                box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
                 overflow: hidden;
-                box-shadow:
-                    var(--shadow),
-                    0 0 80px rgba(16, 185, 129, 0.06);
+                text-align: left;
             }
             .terminal-bar {
                 display: flex;
                 align-items: center;
                 gap: 8px;
-                padding: 12px 16px;
-                background: var(--bg-subtle);
+                padding: 11px 16px;
+                background: var(--bg-card);
                 border-bottom: 1px solid var(--border);
             }
             .terminal-dot {
-                width: 12px;
-                height: 12px;
+                width: 11px;
+                height: 11px;
                 border-radius: 50%;
             }
             .terminal-dot.red {
                 background: #ff5f57;
             }
             .terminal-dot.yellow {
-                background: #ffbd2e;
+                background: #febc2e;
             }
             .terminal-dot.green {
                 background: #28c840;
             }
             .terminal-title {
-                flex: 1;
-                text-align: center;
+                margin-left: 10px;
                 font-size: 12px;
-                color: var(--text-muted);
-                font-family: monospace;
+                color: var(--text-dim);
+                font-family: 'JetBrains Mono', monospace;
             }
-
             .terminal-body {
-                padding: 20px 24px;
-                font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, monospace;
-                font-size: 14px;
+                padding: 22px 20px;
+                font-family: 'JetBrains Mono', monospace;
+                font-size: 13px;
                 line-height: 1.7;
+                white-space: pre-wrap;
             }
-
-            .t-cmd {
+            .t-prompt {
                 color: var(--green);
             }
-            .t-out {
+            .t-cmd {
                 color: var(--text);
             }
             .t-muted {
+                color: var(--text-dim);
+            }
+            .t-dim {
                 color: var(--text-muted);
             }
             .t-green {
                 color: var(--green);
-                font-weight: 700;
             }
             .t-cyan {
                 color: var(--cyan);
@@ -539,788 +399,260 @@
             .t-yellow {
                 color: var(--yellow);
             }
-            .t-orange {
-                color: var(--orange);
+            .t-indigo {
+                color: var(--indigo);
             }
             .t-red {
                 color: var(--red);
             }
-            .t-indigo {
-                color: var(--indigo);
+            .t-cursor {
+                color: var(--green);
+                animation: blink 1.1s step-end infinite;
             }
-            .t-prompt {
-                color: #64748b;
-            }
-            .t-dim {
-                color: #475569;
+            @keyframes blink {
+                50% {
+                    opacity: 0;
+                }
             }
 
-            /* ── Stats bar ─────────────────────────────────────── */
-            .stats-bar {
-                display: flex;
-                justify-content: center;
-                gap: 48px;
-                flex-wrap: wrap;
-                padding: 40px 0;
-                border-top: 1px solid var(--border);
-                border-bottom: 1px solid var(--border);
+            /* ── Metrics bar ───────────────────────────────────── */
+            .metrics {
+                margin: 64px auto 0;
             }
-            .stat-item {
+            .metrics-grid {
+                display: grid;
+                grid-template-columns: repeat(4, 1fr);
+                gap: 1px;
+                background: var(--border);
+                border: 1px solid var(--border);
+                border-radius: var(--radius);
+                overflow: hidden;
+            }
+            .metric {
+                background: var(--bg-card);
+                padding: 26px 18px;
                 text-align: center;
             }
-            .stat-num {
-                font-size: 32px;
+            .metric-num {
+                font-size: clamp(1.6rem, 3.5vw, 2.3rem);
                 font-weight: 800;
-                letter-spacing: -0.03em;
+                letter-spacing: -0.02em;
+                line-height: 1;
                 background: linear-gradient(135deg, var(--green), var(--cyan));
                 -webkit-background-clip: text;
+                background-clip: text;
                 -webkit-text-fill-color: transparent;
             }
-            .stat-label {
+            .metric-label {
+                margin-top: 8px;
                 font-size: 13px;
                 color: var(--text-muted);
-                margin-top: 2px;
+                font-weight: 500;
+            }
+            @media (max-width: 720px) {
+                .metrics-grid {
+                    grid-template-columns: repeat(2, 1fr);
+                }
             }
 
-            /* ── PROBLEM ───────────────────────────────────────── */
-            #problem {
-                background: var(--bg-subtle);
+            /* ── Section scaffolding ──────────────────────────── */
+            section {
+                padding: 88px 0;
             }
-
-            .problem-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-                gap: 20px;
-                margin-top: 40px;
+            .section-head {
+                text-align: center;
+                max-width: 640px;
+                margin: 0 auto 56px;
             }
-
-            .pain-card {
-                background: var(--bg-card);
-                border: 1px solid var(--border);
-                border-radius: var(--radius);
-                padding: 24px;
-            }
-            .pain-icon {
-                font-size: 28px;
-                margin-bottom: 12px;
-            }
-            .pain-card h3 {
-                font-size: 16px;
+            .section-label {
+                display: inline-block;
+                font-size: 13px;
                 font-weight: 700;
-                margin-bottom: 8px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                color: var(--green);
+                margin-bottom: 14px;
             }
-            .pain-card p {
-                font-size: 14px;
+            .section-head h2 {
+                font-size: clamp(1.8rem, 4vw, 2.6rem);
+                font-weight: 800;
+                letter-spacing: -0.02em;
+                line-height: 1.15;
+            }
+            .section-head p {
+                margin-top: 16px;
                 color: var(--text-muted);
-                line-height: 1.5;
+                font-size: 1.08rem;
             }
 
-            /* ── FEATURES / THREE LEVELS ──────────────────────── */
-            .levels-grid {
+            /* ── Feature cards (3 levels) ─────────────────────── */
+            .levels {
                 display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-                gap: 24px;
-                margin-top: 48px;
+                grid-template-columns: repeat(3, 1fr);
+                gap: 20px;
             }
-
             .level-card {
                 background: var(--bg-card);
-                border-radius: var(--radius-lg);
-                overflow: hidden;
                 border: 1px solid var(--border);
-                transition:
-                    border-color 0.2s,
-                    transform 0.2s;
+                border-radius: var(--radius);
+                padding: 32px 28px;
+                position: relative;
+                transition: border-color 0.18s, transform 0.18s;
             }
             .level-card:hover {
-                transform: translateY(-4px);
-                border-color: var(--green);
+                border-color: var(--border-hover);
+                transform: translateY(-3px);
             }
-            .level-card:nth-child(2):hover {
-                border-color: var(--cyan);
+            .level-card::before {
+                content: '';
+                position: absolute;
+                inset: 0 0 auto 0;
+                height: 3px;
+                border-radius: var(--radius) var(--radius) 0 0;
             }
-            .level-card:nth-child(3):hover {
-                border-color: var(--indigo);
+            .level-card.green::before {
+                background: var(--green);
             }
-
-            .level-header {
-                padding: 24px 24px 16px;
-                border-bottom: 1px solid var(--border);
+            .level-card.cyan::before {
+                background: var(--cyan);
             }
-            .level-num {
-                font-size: 11px;
-                font-weight: 700;
-                letter-spacing: 0.1em;
-                text-transform: uppercase;
-                margin-bottom: 8px;
+            .level-card.indigo::before {
+                background: var(--indigo);
             }
-            .level-num.green {
-                color: var(--green);
-            }
-            .level-num.cyan {
-                color: var(--cyan);
-            }
-            .level-num.indigo {
-                color: var(--indigo);
-            }
-
-            .level-header h3 {
-                font-size: 20px;
-                font-weight: 700;
-                margin-bottom: 6px;
-            }
-            .level-header p {
-                font-size: 14px;
-                color: var(--text-muted);
-            }
-
-            .level-features {
-                padding: 20px 24px;
-                list-style: none;
-            }
-            .level-features li {
-                display: flex;
-                align-items: flex-start;
-                gap: 10px;
-                font-size: 14px;
-                color: var(--text-muted);
-                padding: 7px 0;
-                border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-            }
-            .level-features li:last-child {
-                border-bottom: none;
-            }
-            .level-features .check {
-                flex-shrink: 0;
-                width: 16px;
-                height: 16px;
-                margin-top: 2px;
-            }
-            .level-features .check.green {
-                color: var(--green);
-            }
-            .level-features .check.cyan {
-                color: var(--cyan);
-            }
-            .level-features .check.indigo {
-                color: var(--indigo);
-            }
-
-            /* ── ZONES ─────────────────────────────────────────── */
-            #zones {
-                background: var(--bg-subtle);
-            }
-
-            .zones-list {
-                display: flex;
-                flex-direction: column;
-                gap: 12px;
-                max-width: 700px;
-                margin: 40px auto 0;
-            }
-
-            .zone-row {
-                display: flex;
-                align-items: center;
-                gap: 16px;
-                background: var(--bg-card);
-                border: 1px solid var(--border);
-                border-radius: var(--radius);
-                padding: 16px 20px;
-            }
-            .zone-dot {
-                width: 12px;
-                height: 12px;
-                border-radius: 50%;
-                flex-shrink: 0;
-            }
-            .zone-name {
-                width: 100px;
-                font-weight: 700;
-                font-size: 15px;
-                flex-shrink: 0;
-            }
-            .zone-action {
-                flex: 1;
-                font-size: 14px;
-                color: var(--text-muted);
-            }
-            .zone-pct {
+            .level-tag {
                 font-size: 12px;
                 font-weight: 700;
-                padding: 2px 8px;
-                border-radius: 999px;
-                flex-shrink: 0;
-            }
-
-            /* ── STATUSLINE PREVIEW ─────────────────────────────── */
-            #statusline-preview {
-                background: var(--bg-subtle);
-            }
-
-            .sl-grid {
-                display: flex;
-                flex-direction: column;
-                gap: 16px;
-                margin-top: 48px;
-            }
-
-            .sl-zone-block {
-                border-radius: var(--radius);
-                overflow: hidden;
-                border: 1px solid var(--border);
-            }
-
-            .sl-zone-label {
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                padding: 10px 16px;
-                background: var(--bg-card);
-                border-bottom: 1px solid var(--border);
-                font-size: 12px;
-                font-weight: 700;
+                letter-spacing: 0.06em;
                 text-transform: uppercase;
-                letter-spacing: 0.08em;
             }
-
-            .sl-dot {
-                width: 10px;
-                height: 10px;
-                border-radius: 50%;
-                flex-shrink: 0;
-            }
-
-            .sl-terminal {
-                background: var(--bg-subtle);
-                padding: 14px 20px;
-                font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, monospace;
-                font-size: 13px;
-                line-height: 1.6;
-                overflow-x: auto;
-            }
-
-            .sl-bar {
-                display: inline-flex;
-                align-items: center;
-                gap: 6px;
-                flex-wrap: wrap;
-            }
-
-            .sl-seg {
-                white-space: nowrap;
-            }
-
-            /* ── HOW IT WORKS ──────────────────────────────────── */
-            .steps {
-                display: flex;
-                flex-direction: column;
-                gap: 0;
-                margin-top: 48px;
-                max-width: 820px;
-            }
-
-            .step-arrow {
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                color: var(--border);
-                font-size: 20px;
-                height: 28px;
-                margin-left: 40px; /* align with step-num center (44px/2 - border) */
-            }
-
-            .step {
-                display: grid;
-                grid-template-columns: 44px 1fr;
-                gap: 20px;
-                align-items: start;
-                text-align: left;
-                padding: 28px 32px;
-                background: var(--bg-card);
-                border: 1px solid var(--border);
-                border-radius: var(--radius-lg);
-            }
-
-            .step-body {
-            }
-
-            .step h3 {
-                font-size: 16px;
-                font-weight: 700;
-                margin-bottom: 6px;
-            }
-
-            .step p {
-                font-size: 14px;
-                color: var(--text-muted);
-                margin-bottom: 0;
-            }
-
-            .step code {
-                display: block;
-                background: var(--bg-subtle);
-                border: 1px solid var(--border);
-                border-radius: 8px;
-                padding: 10px 14px;
-                font-family: monospace;
-                font-size: 13px;
-                color: var(--cyan);
-                margin-top: 10px;
-                text-align: left;
-            }
-
-            .step-num {
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                width: 44px;
-                height: 44px;
-                border-radius: 50%;
-                background: rgba(16, 185, 129, 0.1);
-                border: 2px solid var(--green);
-                font-size: 18px;
-                font-weight: 800;
+            .level-card.green .level-tag {
                 color: var(--green);
-                margin-bottom: 16px;
             }
-
-            .step h3 {
-                font-size: 16px;
-                font-weight: 700;
-                margin-bottom: 8px;
-            }
-
-            .step p {
-                font-size: 14px;
-                color: var(--text-muted);
-            }
-
-            .step code {
-                display: block;
-                background: var(--bg-subtle);
-                border: 1px solid var(--border);
-                border-radius: 8px;
-                padding: 10px 14px;
-                font-family: monospace;
-                font-size: 13px;
+            .level-card.cyan .level-tag {
                 color: var(--cyan);
-                margin-top: 10px;
-                text-align: left;
             }
-
-            /* ── OUTPUT EXAMPLES ──────────────────────────────── */
-            #examples {
-                background: var(--bg);
-            }
-
-            .examples-tabs {
-                display: flex;
-                gap: 8px;
-                margin-bottom: 0;
-                border-bottom: 1px solid var(--border);
-                padding-bottom: 0;
-            }
-
-            .tab-btn {
-                background: none;
-                border: none;
-                border-bottom: 2px solid transparent;
-                padding: 10px 20px;
-                font-size: 14px;
-                font-weight: 600;
-                color: var(--text-muted);
-                cursor: pointer;
-                font-family: inherit;
-                transition:
-                    color 0.2s,
-                    border-color 0.2s;
-                margin-bottom: -1px;
-            }
-            .tab-btn:hover {
-                color: var(--text);
-            }
-            .tab-btn.active {
-                color: var(--cyan);
-                border-bottom-color: var(--cyan);
-            }
-            .tab-btn.active.green {
-                color: var(--green);
-                border-bottom-color: var(--green);
-            }
-            .tab-btn.active.indigo {
+            .level-card.indigo .level-tag {
                 color: var(--indigo);
-                border-bottom-color: var(--indigo);
             }
-
-            .tab-panel {
-                display: none;
+            .level-card h3 {
+                font-size: 1.35rem;
+                font-weight: 700;
+                margin: 12px 0 10px;
+                letter-spacing: -0.01em;
             }
-            .tab-panel.active {
-                display: block;
+            .level-card p {
+                color: var(--text-muted);
+                font-size: 0.97rem;
+                margin-bottom: 18px;
             }
-
-            .example-terminal {
-                background: var(--bg-subtle);
+            .level-card code {
+                display: inline-block;
+                background: var(--bg-deep);
                 border: 1px solid var(--border);
-                border-top: none;
-                border-radius: 0 0 var(--radius-lg) var(--radius-lg);
-                overflow: hidden;
-            }
-
-            .example-terminal-body {
-                padding: 20px 24px;
-                font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, monospace;
-                font-size: 13px;
-                line-height: 1.65;
-                overflow-x: auto;
-            }
-
-            .t-border {
-                color: #4b5563;
-            }
-            .t-h1 {
+                border-radius: 6px;
+                padding: 6px 10px;
+                font-size: 12.5px;
                 color: var(--cyan);
-                font-weight: 700;
             }
-            .t-h2 {
-                color: var(--indigo);
-                font-weight: 700;
-            }
-            .t-key {
-                color: var(--text-muted);
-            }
-            .t-val {
-                color: var(--text);
-            }
-            .t-money {
-                color: var(--green);
-                font-weight: 700;
-            }
-            .t-bar-g {
-                color: var(--green);
-            }
-            .t-bar-y {
-                color: var(--yellow);
-            }
-            .t-bar-o {
-                color: var(--orange);
-            }
-            .t-bar-r {
-                color: var(--red);
-            }
-            .t-bar-d {
-                color: #4b5563;
+            @media (max-width: 820px) {
+                .levels {
+                    grid-template-columns: 1fr;
+                }
             }
 
-            /* ── SCREENSHOTS ───────────────────────────────────── */
-            .screenshots-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-                gap: 20px;
-                margin-top: 48px;
-            }
-
-            .screenshot-card {
-                background: var(--bg-card);
-                border: 1px solid var(--border);
-                border-radius: var(--radius-lg);
-                overflow: hidden;
-            }
-
-            .screenshot-card img {
-                width: 100%;
-                display: block;
-            }
-
-            .screenshot-caption {
-                padding: 12px 16px;
-                font-size: 13px;
-                color: var(--text-muted);
-                text-align: center;
-                border-top: 1px solid var(--border);
-            }
-
-            /* ── FAQ ───────────────────────────────────────────── */
-            .faq-list {
-                max-width: 720px;
-                margin: 40px auto 0;
-                display: flex;
-                flex-direction: column;
-                gap: 12px;
-            }
-
-            details {
-                background: var(--bg-card);
+            /* ── Detail CTA banner ────────────────────────────── */
+            .detail-banner {
+                background: linear-gradient(135deg, var(--bg-card), var(--bg-subtle));
                 border: 1px solid var(--border);
                 border-radius: var(--radius);
-                overflow: hidden;
-            }
-
-            summary {
-                padding: 18px 20px;
-                font-weight: 600;
-                font-size: 15px;
-                cursor: pointer;
-                list-style: none;
+                padding: 40px;
                 display: flex;
+                align-items: center;
                 justify-content: space-between;
-                align-items: center;
-                user-select: none;
-            }
-            summary::-webkit-details-marker {
-                display: none;
-            }
-            summary::after {
-                content: '+';
-                font-size: 20px;
-                color: var(--text-muted);
-                transition: transform 0.2s;
-            }
-            details[open] summary::after {
-                content: '−';
-            }
-
-            details p {
-                padding: 0 20px 18px;
-                color: var(--text-muted);
-                font-size: 14px;
-                line-height: 1.6;
-            }
-
-            details code {
-                background: var(--bg-subtle);
-                padding: 2px 6px;
-                border-radius: 4px;
-                font-family: monospace;
-                font-size: 13px;
-                color: var(--cyan);
-            }
-
-            /* ── FINAL CTA ─────────────────────────────────────── */
-            .cta-section {
-                text-align: center;
-                background: linear-gradient(
-                    135deg,
-                    rgba(16, 185, 129, 0.06),
-                    rgba(129, 140, 248, 0.06)
-                );
-                border-top: 1px solid var(--border);
-                border-bottom: 1px solid var(--border);
-            }
-
-            .cta-section h2 {
-                font-size: clamp(28px, 4vw, 44px);
-            }
-
-            .cta-section .lead {
-                margin: 0 auto 36px;
-            }
-
-            .trust-badges {
-                display: flex;
-                justify-content: center;
                 gap: 24px;
                 flex-wrap: wrap;
-                margin-top: 36px;
+            }
+            .detail-banner h3 {
+                font-size: 1.5rem;
+                font-weight: 800;
+                letter-spacing: -0.01em;
+            }
+            .detail-banner p {
+                color: var(--text-muted);
+                margin-top: 6px;
+                max-width: 520px;
             }
 
+            /* ── Final CTA ────────────────────────────────────── */
+            .cta-section {
+                text-align: center;
+            }
+            .cta-section h2 {
+                font-size: clamp(2rem, 5vw, 3rem);
+                font-weight: 800;
+                letter-spacing: -0.02em;
+                line-height: 1.1;
+                margin-bottom: 18px;
+            }
+            .cta-section .lead {
+                color: var(--text-muted);
+                font-size: 1.1rem;
+                margin-bottom: 32px;
+            }
+            .trust-badges {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 24px;
+                margin-top: 40px;
+                font-size: 13.5px;
+                color: var(--text-muted);
+            }
             .badge {
                 display: inline-flex;
                 align-items: center;
-                gap: 6px;
-                background: var(--bg-card);
-                border: 1px solid var(--border);
-                border-radius: 999px;
-                padding: 6px 14px;
-                font-size: 13px;
-                color: var(--text-muted);
+                gap: 7px;
             }
 
-            /* ── FOOTER ────────────────────────────────────────── */
+            /* ── Footer ───────────────────────────────────────── */
             footer {
-                padding: 40px 0;
                 border-top: 1px solid var(--border);
+                padding: 36px 0;
             }
-
             .footer-inner {
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
-                flex-wrap: wrap;
-                gap: 16px;
-            }
-
-            .footer-logo {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-            }
-            .footer-logo img {
-                height: 28px;
-            }
-            .footer-logo span {
-                font-size: 14px;
-                color: var(--text-muted);
-            }
-
-            .footer-links {
-                display: flex;
                 gap: 20px;
-                list-style: none;
-            }
-            .footer-links a {
-                font-size: 13px;
-                color: var(--text-muted);
-            }
-            .footer-links a:hover {
-                color: var(--text);
-                text-decoration: none;
-            }
-
-            /* ── CACHE KEEP-WARM ─────────────────────────────── */
-            #cache-warm {
-                background: var(--bg-subtle);
-            }
-
-            .cw-layout {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: 48px;
-                margin-top: 48px;
-                align-items: start;
-            }
-
-            .cw-scenario {
-                background: var(--bg-card);
-                border: 1px solid var(--border);
-                border-radius: var(--radius);
-                padding: 16px 20px;
-                margin-bottom: 14px;
-            }
-            .cw-scenario-label {
-                font-size: 11px;
-                font-weight: 700;
-                text-transform: uppercase;
-                letter-spacing: 0.1em;
-                margin-bottom: 12px;
-            }
-            .cw-scenario-label.bad {
-                color: var(--red);
-            }
-            .cw-scenario-label.good {
-                color: var(--green);
-            }
-
-            .cw-track {
-                display: flex;
-                align-items: center;
                 flex-wrap: wrap;
-                gap: 4px;
-                font-family: 'SF Mono', Consolas, monospace;
-                font-size: 11px;
-                line-height: 1.8;
             }
-            .cw-event {
-                display: inline-flex;
-                align-items: center;
-                gap: 3px;
-                padding: 2px 8px;
-                border-radius: 6px;
-                font-weight: 700;
-                white-space: nowrap;
-            }
-            .cw-event.req {
-                background: rgba(0, 255, 65, 0.12);
-                color: var(--green);
-            }
-            .cw-event.hb {
-                background: rgba(6, 182, 212, 0.12);
-                color: var(--cyan);
-            }
-            .cw-event.exp {
-                background: rgba(239, 68, 68, 0.12);
-                color: var(--red);
-            }
-            .cw-event.hit {
-                background: rgba(0, 255, 65, 0.12);
-                color: var(--green);
-            }
-            .cw-event.miss {
-                background: rgba(239, 68, 68, 0.12);
-                color: var(--red);
-            }
-            .cw-arrow {
-                color: var(--gray);
-                font-size: 11px;
-            }
-
-            .cw-stat-rows {
-                display: flex;
-                flex-direction: column;
-                gap: 10px;
-                margin: 24px 0;
-            }
-            .cw-stat-row {
+            .footer-logo {
                 display: flex;
                 align-items: center;
                 gap: 12px;
                 font-size: 14px;
                 color: var(--text-muted);
             }
-            .cw-badge {
-                display: inline-block;
-                background: rgba(0, 255, 65, 0.1);
-                border: 1px solid rgba(0, 255, 65, 0.2);
+            .footer-logo img {
+                height: 36px;
+            }
+            .footer-logo a {
                 color: var(--green);
-                font-weight: 700;
-                font-size: 12px;
-                padding: 2px 10px;
-                border-radius: 999px;
-                white-space: nowrap;
-                flex-shrink: 0;
             }
-            .cw-savings {
-                background: linear-gradient(
-                    135deg,
-                    rgba(0, 255, 65, 0.06),
-                    rgba(6, 182, 212, 0.06)
-                );
-                border: 1px solid rgba(0, 255, 65, 0.2);
-                border-radius: var(--radius);
-                padding: 24px;
-                text-align: center;
-                margin-top: 4px;
+            .footer-links {
+                list-style: none;
+                display: flex;
+                gap: 24px;
+                font-size: 14px;
             }
-            .cw-savings-num {
-                font-size: 44px;
-                font-weight: 800;
-                background: linear-gradient(135deg, var(--green), var(--cyan));
-                -webkit-background-clip: text;
-                -webkit-text-fill-color: transparent;
-                letter-spacing: -0.03em;
-                line-height: 1;
-            }
-            .cw-savings-label {
-                font-size: 13px;
+            .footer-links a {
                 color: var(--text-muted);
-                margin-top: 8px;
-                line-height: 1.5;
+                transition: color 0.15s;
             }
-
-            /* ── Responsive ────────────────────────────────────── */
-            @media (max-width: 768px) {
-                .cw-layout {
-                    grid-template-columns: 1fr;
-                }
+            .footer-links a:hover {
+                color: var(--text);
             }
-            @media (max-width: 640px) {
-                .nav-links {
-                    display: none;
-                }
-                .stats-bar {
-                    gap: 28px;
-                }
+            @media (max-width: 600px) {
                 .footer-inner {
                     flex-direction: column;
                     text-align: center;
@@ -1329,35 +661,32 @@
         </style>
     </head>
     <body>
-        <!-- ── NAV ──────────────────────────────────────────────────── -->
+        <!-- ── NAV ──────────────────────────────────────────────── -->
         <nav>
             <div class="nav-inner">
-                <div class="nav-logo">
-                    <img src="assets/logo/logo-full.svg" alt="context-stats" />
-                </div>
+                <a class="nav-logo" href="/context-stats/" aria-label="context-stats home">
+                    <img src="assets/logo/logo-mark.svg" alt="context-stats" />
+                    <span class="nav-wordmark">Context<span class="stats">Stats</span></span>
+                </a>
                 <ul class="nav-links">
-                    <li><a href="#whats-new">v1.22.0</a></li>
-                    <li><a href="#features">Features</a></li>
-                    <li><a href="#cache-warm">Cache Warm</a></li>
-                    <li><a href="#how-it-works">Install</a></li>
-                    <li><a href="#examples">Examples</a></li>
-                    <li><a href="#zones">Zones</a></li>
-                    <li><a href="#faq">FAQ</a></li>
+                    <li><a href="#levels">Features</a></li>
+                    <li><a href="docs.html">Documentation</a></li>
+                    <li><a href="https://pypi.org/project/context-stats/">PyPI</a></li>
                     <li>
                         <a href="https://github.com/luongnv89/context-stats" class="nav-cta"
-                            >GitHub</a
+                            >GitHub ★</a
                         >
                     </li>
                 </ul>
             </div>
         </nav>
 
-        <!-- ── HERO ─────────────────────────────────────────────────── -->
+        <!-- ── HERO ─────────────────────────────────────────────── -->
         <section class="hero">
             <div class="container">
                 <div class="hero-badge">
                     <span class="dot"></span>
-                    v1.22.0 — Thinking level and PR context in your statusline
+                    v1.22.0 — Live context monitoring for Claude Code
                 </div>
 
                 <h1>
@@ -1367,33 +696,19 @@
                 </h1>
 
                 <p class="hero-sub">
-                    Real-time context monitoring for Claude Code. Track token usage, catch
-                    degradation early, and understand your AI spend — all without leaving your
+                    Real-time context-window monitoring for Claude Code. See your token usage,
+                    catch degradation early, and understand your AI spend — without leaving the
                     terminal.
                 </p>
 
                 <div class="hero-actions">
-                    <a href="#how-it-works" class="btn-primary">
-                        <svg
-                            width="16"
-                            height="16"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2.5"
-                        >
+                    <a href="https://pypi.org/project/context-stats/" class="btn-primary">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                             <path d="M12 5v14M5 12l7 7 7-7" />
                         </svg>
-                        Install in 60 seconds
+                        pip install context-stats
                     </a>
-                    <a href="https://github.com/luongnv89/context-stats" class="btn-secondary">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                            <path
-                                d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
-                            />
-                        </svg>
-                        View on GitHub
-                    </a>
+                    <a href="docs.html" class="btn-secondary">Read the docs →</a>
                 </div>
 
                 <!-- Terminal Demo -->
@@ -1403,85 +718,74 @@
                             <span class="terminal-dot red"></span>
                             <span class="terminal-dot yellow"></span>
                             <span class="terminal-dot green"></span>
-                            <span class="terminal-title"
-                                >Claude Code — context-stats live statusline</span
-                            >
+                            <span class="terminal-title">Claude Code — context-stats live</span>
                         </div>
-                        <div class="terminal-body">
-                            <div>
-                                <span class="t-prompt">$ </span
-                                ><span class="t-cmd">pip install context-stats</span>
-                            </div>
-                            <div class="t-muted">Successfully installed context-stats-1.22.0</div>
-                            <br />
-                            <div>
-                                <span class="t-prompt">$ </span
-                                ><span class="t-cmd">context-stats graph</span>
-                            </div>
-                            <br />
-                            <div class="t-muted">Context usage — last 12 interactions</div>
-                            <div class="t-green">▓▓▓▓▓▓▓▓░░░░░░ 64,000 free (32.0%)</div>
-                            <br />
-                            <div class="t-dim">╔══ Session: abc-123 ══════════════╗</div>
-                            <div class="t-dim">
-                                ║ Model: <span class="t-cyan">Claude Opus 4.6</span> ║
-                            </div>
-                            <div class="t-dim">
-                                ║ Zone: <span class="t-yellow">◆ Code-only</span> ║
-                            </div>
-                            <div class="t-dim">
-                                ║ MI: <span class="t-green">0.918</span> (high) ║
-                            </div>
-                            <div class="t-dim">
-                                ║ Delta: <span class="t-cyan">+2,500</span> tokens this step ║
-                            </div>
-                            <div class="t-dim">╚══════════════════════════════════╝</div>
-                            <br />
-                            <div class="t-muted">Delta per interaction:</div>
-                            <div class="t-green">1│ ██</div>
-                            <div class="t-green">2│ ████</div>
-                            <div class="t-yellow">3│ ████████</div>
-                            <div class="t-red">
-                                4│ <span style="color: #ef4444">▼</span
-                                ><span class="t-muted"> compact (MI 0.61 ⚠ lossy)</span>
-                            </div>
-                            <div class="t-green">5│ ██</div>
-                            <div class="t-yellow">6│ ████████████</div>
-                            <br />
-                            <div>
-                                <span class="t-prompt">$ </span><span class="t-cursor">█</span>
-                            </div>
+                        <div class="terminal-body"><span class="t-muted"># Always-on statusline in Claude Code</span>
+<span class="t-green">meta-app</span><span class="t-dim"> | </span><span class="t-cyan">feat/85-catalog-visibility-toggle</span> <span class="t-cyan">[3]</span><span class="t-dim"> | </span><span class="t-yellow">132,944 (66.5%)</span><span class="t-dim"> | </span><span class="t-dim">Code</span><span class="t-dim"> | </span><span class="t-dim">3.3 tok/s</span><span class="t-dim"> | </span><span class="t-dim">Sonnet 4.6</span><span class="t-dim"> | </span><span class="t-dim">baaff3c8-2b25-458b-adcd-96ebdeb5125d</span>
+
+<span class="t-prompt">$ </span><span class="t-cmd">context-stats graph</span>
+
+<span class="t-dim">Token Usage Graphs (Session: a3f9c12d…)</span>
+
+<span class="t-muted">Cumulative Token Usage   Max: 53,250</span>
+<span class="t-green">53,250 ┤            ▄▄▟███████</span>
+<span class="t-green">37,192 ┤        ▗▄██████████</span>
+<span class="t-green">25,148 ┤▄▄▄▄▟███</span>
+<span class="t-dim">       └16:25──────16:27──────16:34</span>
+
+<span class="t-muted">Token Delta Per Interval   Max: 25,148</span>
+<span class="t-cyan">25,148 ┤▌        ▖     ▟</span>
+<span class="t-cyan">     0 ┤▁▁▁▂▁▁▁▁█▁▁▁▁██▁</span>
+
+<span class="t-muted">Summary Statistics</span>
+<span class="t-dim">Current Tokens:   </span><span class="t-green">53,250</span>
+<span class="t-dim">Session Duration: </span>8m
+<span class="t-dim">Average Delta:    </span><span class="t-cyan">2,958</span>
+<span class="t-dim">Total Growth:     </span><span class="t-green">28,102</span>
+
+<span class="t-prompt">$ </span><span class="t-cursor">█</span></div>
+                    </div>
+                </div>
+
+                <!-- ── METRICS BAR ──────────────────────────────── -->
+                <div class="metrics">
+                    <div class="metrics-grid">
+                        <div class="metric">
+                            <div class="metric-num" id="stat-stars">—</div>
+                            <div class="metric-label">GitHub stars</div>
+                        </div>
+                        <div class="metric">
+                            <div class="metric-num" id="stat-forks">—</div>
+                            <div class="metric-label">Forks</div>
+                        </div>
+                        <div class="metric">
+                            <div class="metric-num" id="stat-downloads">—</div>
+                            <div class="metric-label">PyPI downloads</div>
+                        </div>
+                        <div class="metric">
+                            <div class="metric-num">3</div>
+                            <div class="metric-label">Analytics levels</div>
+                        </div>
+                        <div class="metric">
+                            <div class="metric-num">5</div>
+                            <div class="metric-label">Context zones</div>
+                        </div>
+                        <div class="metric">
+                            <div class="metric-num">0</div>
+                            <div class="metric-label">Network calls</div>
+                        </div>
+                        <div class="metric">
+                            <div class="metric-num">60s</div>
+                            <div class="metric-label">To set up</div>
+                        </div>
+                        <div class="metric">
+                            <div class="metric-num">MIT</div>
+                            <div class="metric-label">Free forever</div>
                         </div>
                     </div>
                 </div>
             </div>
         </section>
-
-        <!-- ── STATS BAR ─────────────────────────────────────────────── -->
-        <div class="container">
-            <div class="stats-bar">
-                <div class="stat-item">
-                    <div class="stat-num" id="stat-stars">—</div>
-                    <div class="stat-label">GitHub stars</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num" id="stat-forks">—</div>
-                    <div class="stat-label">Forks</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num" id="stat-downloads">—</div>
-                    <div class="stat-label">PyPI downloads</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">0</div>
-                    <div class="stat-label">Dependencies</div>
-                </div>
-                <div class="stat-item">
-                    <div class="stat-num">MIT</div>
-                    <div class="stat-label">Free forever</div>
-                </div>
-            </div>
-        </div>
 
         <script>
             (function () {
@@ -1500,7 +804,7 @@
                         if (f && d.forks_count !== undefined) f.textContent = fmt(d.forks_count);
                     })
                     .catch(() => {});
-                // PyPI total downloads (last month via pypistats)
+                // PyPI downloads (last month via pypistats)
                 fetch('https://pypistats.org/api/packages/context-stats/recent')
                     .then(r => r.json())
                     .then(d => {
@@ -1513,1759 +817,86 @@
             })();
         </script>
 
-        <!-- ── PROBLEM ───────────────────────────────────────────────── -->
-        <section id="problem">
+        <!-- ── 3 LEVELS ─────────────────────────────────────────── -->
+        <section id="levels">
             <div class="container">
-                <span class="section-label">The Problem</span>
-                <h2>Claude Code doesn't tell you<br />when you're in trouble.</h2>
-                <p class="lead">
-                    By the time you notice output quality dropping, you've already wasted tokens —
-                    and money.
-                </p>
-
-                <div class="problem-grid">
-                    <div class="pain-card">
-                        <div class="pain-icon">🪫</div>
-                        <h3>Invisible context drain</h3>
-                        <p>
-                            Each tool call, each file read quietly consumes context. You only find
-                            out when Claude starts looping or forgetting what it just wrote.
-                        </p>
-                    </div>
-                    <div class="pain-card">
-                        <div class="pain-icon">💸</div>
-                        <h3>Surprise API bills</h3>
-                        <p>
-                            A single runaway session can burn thousands of tokens before you realize
-                            the model is operating at 20% intelligence. No warning, no way to see
-                            trends.
-                        </p>
-                    </div>
-                    <div class="pain-card">
-                        <div class="pain-icon">📉</div>
-                        <h3>Silent model degradation</h3>
-                        <p>
-                            As context fills, Claude's effective intelligence drops along a
-                            measurable curve. Running at 30% context free isn't the same as running
-                            at 80% free.
-                        </p>
-                    </div>
-                    <div class="pain-card">
-                        <div class="pain-icon">🌀</div>
-                        <h3>No session history</h3>
-                        <p>
-                            After a session ends, you can't audit what happened — which interactions
-                            consumed the most tokens or why a particular task ballooned the context.
-                        </p>
-                    </div>
-                    <div class="pain-card">
-                        <div class="pain-icon">⏱️</div>
-                        <h3>Silent cache expiry</h3>
-                        <p>
-                            Claude's prompt cache has a 5-minute TTL. Every pause — a review, a
-                            coffee, a long think — silently evicts it. Your next request pays full
-                            token price again, with no warning and no way to tell.
-                        </p>
-                    </div>
-                    <div class="pain-card">
-                        <div class="pain-icon">🗜️</div>
-                        <h3>Lossy compaction, no warning</h3>
-                        <p>
-                            When Claude compacts its context at low model intelligence, the summary
-                            is lossy — key details get lost. You have no idea when it happened or
-                            how degraded the model was at the time.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- ── WHAT'S NEW ─────────────────────────────────────────────── -->
-        <section id="whats-new">
-            <div class="container">
-                <span class="section-label">What's New</span>
-                <h2>v1.22.0 — Session context,<br />right where you work.</h2>
-                <p class="lead">
-                    See more of the context that matters while you work: Claude's thinking level
-                    beside the model name, plus the active pull request number when enabled.
-                </p>
-
-                <div class="problem-grid">
-                    <div class="pain-card" style="border-color: rgba(0, 255, 65, 0.2)">
-                        <div class="pain-icon">📋</div>
-                        <h3 style="color: var(--green)">Thinking level in your statusline</h3>
-                        <p>
-                            Claude's thinking level now appears next to the model name, making it easier
-                            to understand the current session mode without leaving your terminal.
-                        </p>
-                    </div>
-                    <div class="pain-card" style="border-color: rgba(0, 255, 65, 0.2)">
-                        <div class="pain-icon">⚡</div>
-                        <h3 style="color: var(--cyan)">PR number indicator</h3>
-                        <p>
-                            When you are working on a GitHub pull request, the statusline can show the
-                            current PR number alongside branch context. Enable or disable it with
-                            the <code>show_pr</code> toggle.
-                        </p>
-                    </div>
-                    <div class="pain-card" style="border-color: rgba(0, 255, 65, 0.2)">
-                        <div class="pain-icon">🛡</div>
-                        <h3 style="color: var(--yellow)">Less context switching</h3>
-                        <p>
-                            Model, branch, PR, and thinking-level cues stay visible in one compact line,
-                            so you can keep coding without checking separate commands or browser tabs.
-                        </p>
-                    </div>
-                    <div class="pain-card" style="border-color: rgba(0, 255, 65, 0.2)">
-                        <div class="pain-icon">🧹</div>
-                        <h3 style="color: var(--indigo)">Still lightweight</h3>
-                        <p>
-                            The new indicators extend the existing local-only statusline flow while
-                            preserving the project’s zero-network, append-only state-file design.
-                        </p>
-                    </div>
-                </div>
-
-                <div style="text-align: center; margin-top: 32px">
-                    <a
-                        href="https://github.com/luongnv89/context-stats/releases/tag/v1.22.0"
-                        class="btn-secondary"
-                        style="display: inline-flex"
-                    >
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                            <path
-                                d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
-                            />
-                        </svg>
-                        Full changelog on GitHub
-                    </a>
-                </div>
-            </div>
-        </section>
-
-        <!-- ── FEATURES ──────────────────────────────────────────────── -->
-        <section id="features">
-            <div class="container">
-                <span class="section-label">The Solution</span>
-                <h2>Three levels of analytics,<br />one lightweight tool.</h2>
-                <p class="lead">
-                    From real-time awareness to multi-week cost reports — context-stats gives you
-                    complete visibility without ever leaving your terminal.
-                </p>
-
-                <div class="levels-grid">
-                    <!-- Level 1 -->
-                    <div class="level-card">
-                        <div class="level-header">
-                            <div class="level-num green">Level 1 — Live</div>
-                            <h3>Real-Time Statusline</h3>
-                            <p>
-                                Persistent status line in your Claude Code session — always on, zero
-                                friction.
-                            </p>
-                        </div>
-                        <ul class="level-features">
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Context zone with color-coded action signal + recommendation
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Model Intelligence (MI) score per interaction
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Token delta since last refresh
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Git branch + project name
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Live ASCII graph dashboard (<code>context-stats graph</code>)
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Compaction event detection — <code>▼</code> markers show when &amp;
-                                where Claude compacted
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                MI quality flag at compaction — warns if summary was created at low
-                                intelligence
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Session listing — <code>context-stats sessions</code> shows recent
-                                sessions with metadata
-                            </li>
-                            <li>
-                                <svg class="check green" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Auto-detect latest session — no session ID needed for any command
-                            </li>
-                        </ul>
-                    </div>
-
-                    <!-- Level 2 -->
-                    <div class="level-card">
-                        <div class="level-header">
-                            <div class="level-num cyan">Level 2 — Session</div>
-                            <h3>Per-Session Deep Dive</h3>
-                            <p>Export a detailed Markdown report for any completed session.</p>
-                        </div>
-                        <ul class="level-features">
-                            <li>
-                                <svg class="check cyan" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Executive snapshot with model, duration, interactions
-                            </li>
-                            <li>
-                                <svg class="check cyan" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Interaction timeline with per-step context + MI
-                            </li>
-                            <li>
-                                <svg class="check cyan" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Cache activity analysis (creation vs. read ratio)
-                            </li>
-                            <li>
-                                <svg class="check cyan" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Mermaid visual charts (context growth, zones, cache)
-                            </li>
-                            <li
-                                style="
-                                    background: rgba(0, 255, 65, 0.04);
-                                    border-radius: 6px;
-                                    padding: 8px 10px;
-                                    margin-top: 4px;
-                                    border-bottom: none !important;
-                                "
-                            >
-                                <svg class="check cyan" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                <span
-                                    >Cache keep-warm — heartbeat every 4 min to prevent costly cache
-                                    misses &nbsp;<a
-                                        href="#cache-warm"
-                                        style="
-                                            background: rgba(0, 255, 65, 0.15);
-                                            color: var(--green);
-                                            font-size: 10px;
-                                            font-weight: 700;
-                                            padding: 1px 7px;
-                                            border-radius: 999px;
-                                            letter-spacing: 0.05em;
-                                            text-decoration: none;
-                                        "
-                                        >details ↓</a
-                                    ></span
-                                >
-                            </li>
-                        </ul>
-                    </div>
-
-                    <!-- Level 3 -->
-                    <div class="level-card">
-                        <div class="level-header">
-                            <div class="level-num indigo">Level 3 — Report</div>
-                            <h3>Multi-Week Analytics</h3>
-                            <p>
-                                Understand cost trends, model mix, and efficiency across all your
-                                projects.
-                            </p>
-                        </div>
-                        <ul class="level-features">
-                            <li>
-                                <svg class="check indigo" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Cost breakdown by model family (Opus/Sonnet/Haiku)
-                            </li>
-                            <li>
-                                <svg class="check indigo" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Daily activity heatmaps
-                            </li>
-                            <li>
-                                <svg class="check indigo" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Cross-project efficiency metrics
-                            </li>
-                            <li>
-                                <svg class="check indigo" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                41%+ cache hit ratio analysis
-                            </li>
-                            <li>
-                                <svg class="check indigo" viewBox="0 0 16 16" fill="currentColor">
-                                    <path
-                                        d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
-                                    />
-                                </svg>
-                                Cost optimization opportunities
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- ── CACHE KEEP-WARM ────────────────────────────────────────── -->
-        <section id="cache-warm">
-            <div class="container">
-                <span class="section-label">Cache Optimization</span>
-                <h2>Never let your prompt cache<br />expire mid-session.</h2>
-                <p class="lead">
-                    Claude's prompt cache has a strict
-                    <strong style="color: var(--yellow)">5-minute TTL</strong>. One idle gap — a
-                    review pause, a coffee, a long think — silently evicts it. Your next request
-                    pays full token price, no warning.
-                </p>
-
-                <div class="cw-layout">
-                    <!-- Left: timeline explanation + stats -->
-                    <div>
-                        <div class="cw-scenario">
-                            <div class="cw-scenario-label bad">✗ Without cache-warm</div>
-                            <div class="cw-track">
-                                <span class="cw-event req">request</span>
-                                <span class="cw-arrow">──── 5+ min idle ────</span>
-                                <span class="cw-event exp">cache expired</span>
-                                <span class="cw-arrow">──</span>
-                                <span class="cw-event miss">cache miss 💸</span>
-                            </div>
-                            <div
-                                style="
-                                    margin-top: 10px;
-                                    font-size: 12px;
-                                    color: var(--red);
-                                    line-height: 1.5;
-                                "
-                            >
-                                All context tokens re-processed at full price. No warning. No way to
-                                know it happened.
-                            </div>
-                        </div>
-
-                        <div class="cw-scenario">
-                            <div class="cw-scenario-label good">✓ With cache-warm on</div>
-                            <div class="cw-track">
-                                <span class="cw-event req">request</span>
-                                <span class="cw-arrow">── 4 min ──</span>
-                                <span class="cw-event hb">♥ heartbeat</span>
-                                <span class="cw-arrow">── 4 min ──</span>
-                                <span class="cw-event hb">♥ heartbeat</span>
-                                <span class="cw-arrow">──</span>
-                                <span class="cw-event hit">cache hit ✓</span>
-                            </div>
-                            <div
-                                style="
-                                    margin-top: 10px;
-                                    font-size: 12px;
-                                    color: var(--green);
-                                    line-height: 1.5;
-                                "
-                            >
-                                Cache stays alive. Next request reads cached tokens at ~10% the cost
-                                of uncached.
-                            </div>
-                        </div>
-
-                        <div class="cw-stat-rows">
-                            <div class="cw-stat-row">
-                                <span class="cw-badge">4 min</span>
-                                heartbeat interval — always under the 5-min TTL
-                            </div>
-                            <div class="cw-stat-row">
-                                <span class="cw-badge">30 min</span>
-                                default duration — configure with
-                                <code
-                                    style="
-                                        font-family: monospace;
-                                        font-size: 12px;
-                                        color: var(--cyan);
-                                    "
-                                    >1h</code
-                                >,
-                                <code
-                                    style="
-                                        font-family: monospace;
-                                        font-size: 12px;
-                                        color: var(--cyan);
-                                    "
-                                    >90m</code
-                                >,
-                                <code
-                                    style="
-                                        font-family: monospace;
-                                        font-size: 12px;
-                                        color: var(--cyan);
-                                    "
-                                    >3600s</code
-                                >
-                            </div>
-                            <div class="cw-stat-row">
-                                <span class="cw-badge">background</span>
-                                detached process — zero impact on your Claude session
-                            </div>
-                        </div>
-
-                        <div class="cw-savings">
-                            <div class="cw-savings-num">63.4%</div>
-                            <div class="cw-savings-label">
-                                cache hit rate in a typical session<br />visible in every
-                                <code
-                                    style="
-                                        font-family: monospace;
-                                        font-size: 12px;
-                                        color: var(--cyan);
-                                    "
-                                    >context-stats export</code
-                                >
-                                report
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Right: terminal demo -->
-                    <div>
-                        <div class="terminal">
-                            <div class="terminal-bar">
-                                <span class="terminal-dot red"></span>
-                                <span class="terminal-dot yellow"></span>
-                                <span class="terminal-dot green"></span>
-                                <span class="terminal-title"
-                                    >cache-warm — keep the 5-min TTL alive</span
-                                >
-                            </div>
-                            <div class="terminal-body">
-                                <div class="t-muted">
-                                    # Activate keep-warm for the latest session (no ID needed)
-                                </div>
-                                <div>
-                                    <span class="t-prompt">$ </span
-                                    ><span class="t-cmd">context-stats cache-warm on</span>
-                                </div>
-                                <div class="t-green">Cache keep-warm started</div>
-                                <div>
-                                    <span class="t-key"> Session: </span
-                                    ><span class="t-cyan">abc-1234</span>
-                                </div>
-                                <div>
-                                    <span class="t-key"> Interval: </span
-                                    ><span class="t-cyan">every 4 min</span>
-                                </div>
-                                <div>
-                                    <span class="t-key"> Duration: </span
-                                    ><span class="t-cyan">30 min</span
-                                    ><span class="t-muted"> (expires 14:02)</span>
-                                </div>
-                                <div>
-                                    <span class="t-key"> PID: </span
-                                    ><span class="t-indigo">12845</span>
-                                </div>
-                                <br />
-                                <div class="t-muted"># Use a custom duration</div>
-                                <div>
-                                    <span class="t-prompt">$ </span
-                                    ><span class="t-cmd">context-stats cache-warm on 1h</span>
-                                </div>
-                                <div class="t-green">
-                                    Cache keep-warm started <span class="t-muted">(1h)</span>
-                                </div>
-                                <br />
-                                <div class="t-muted"># Stop the heartbeat early</div>
-                                <div>
-                                    <span class="t-prompt">$ </span
-                                    ><span class="t-cmd">context-stats cache-warm off</span>
-                                </div>
-                                <div class="t-green">Cache keep-warm stopped</div>
-                                <br />
-                                <div class="t-muted"># Verify savings in your session report</div>
-                                <div>
-                                    <span class="t-prompt">$ </span
-                                    ><span class="t-cmd">context-stats export abc-1234</span>
-                                </div>
-                                <div>
-                                    <span class="t-key"> Cache read tokens: </span
-                                    ><span class="t-green">49,120</span
-                                    ><span class="t-muted"> (63.4% hit rate)</span>
-                                </div>
-                                <div>
-                                    <span class="t-key"> Cache savings: </span
-                                    ><span class="t-money">~$0.087</span
-                                    ><span class="t-muted"> (vs. uncached)</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- ── OUTPUT EXAMPLES ───────────────────────────────────────── -->
-        <section id="examples">
-            <div class="container">
-                <span class="section-label">Real Output</span>
-                <h2>What you actually see<br />in the terminal.</h2>
-                <p class="lead">Four commands — each level of analytics, shown in full.</p>
-
-                <div class="examples-tabs">
-                    <button class="tab-btn active green" onclick="switchTab(event, 'tab-graph')">
-                        context-stats graph
-                    </button>
-                    <button class="tab-btn" onclick="switchTab(event, 'tab-sessions')">
-                        context-stats sessions
-                    </button>
-                    <button class="tab-btn" onclick="switchTab(event, 'tab-export')">
-                        context-stats export
-                    </button>
-                    <button class="tab-btn" onclick="switchTab(event, 'tab-report')">
-                        context-stats report
-                    </button>
-                </div>
-
-                <!-- Graph tab -->
-                <div id="tab-graph" class="tab-panel active">
-                    <div class="example-terminal">
-                        <div class="example-terminal-body">
-                            <div>
-                                <span class="t-prompt">$ </span
-                                ><span class="t-cmd">context-stats graph --type all</span>
-                            </div>
-                            <br />
-                            <div class="t-h1">Context Stats (my-project • abc-1234)</div>
-                            <br />
-                            <div class="t-muted">Context usage — last 14 interactions</div>
-                            <div>
-                                <span class="t-bar-g"> ▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░ </span
-                                ><span class="t-key">88,000 free </span
-                                ><span class="t-muted">(44.0%)</span>
-                            </div>
-                            <br />
-                            <div class="t-border">╔══ Session: abc-1234 ═════════════════════╗</div>
-                            <div class="t-border">
-                                ║ <span class="t-key">Model: </span
-                                ><span class="t-cyan">Claude Opus 4.6</span>
-                                <span class="t-border">║</span>
-                            </div>
-                            <div class="t-border">
-                                ║ <span class="t-key">Zone: </span
-                                ><span class="t-yellow">◆ Code-only</span>
-                                <span class="t-border">║</span>
-                            </div>
-                            <div class="t-border">
-                                ║ <span class="t-key">MI: </span
-                                ><span class="t-yellow">0.712</span> (context pressure)
-                                <span class="t-border">║</span>
-                            </div>
-                            <div class="t-border">
-                                ║ <span class="t-key">Delta: </span
-                                ><span class="t-cyan">+3,140</span> tokens this step
-                                <span class="t-border">║</span>
-                            </div>
-                            <div class="t-border">
-                                ║ <span class="t-key">Cost: </span
-                                ><span class="t-money">$0.2847</span>
-                                <span class="t-border">║</span>
-                            </div>
-                            <div class="t-border">╚══════════════════════════════════════════╝</div>
-                            <br />
-                            <div class="t-h2">Context Growth Per Interaction</div>
-                            <div class="t-muted">Max: 8,420 Min: 0 Points: 14</div>
-                            <br />
-                            <div class="t-muted">8,420 │ <span class="t-bar-r">●</span></div>
-                            <div class="t-muted">
-                                │ <span class="t-bar-o">●</span> <span class="t-bar-r">▒</span>
-                            </div>
-                            <div class="t-muted">
-                                │ <span class="t-bar-y">●</span> <span class="t-bar-y">●</span>
-                                <span class="t-bar-o">▒</span> <span class="t-bar-r">░</span>
-                            </div>
-                            <div class="t-muted">
-                                │ <span class="t-bar-g">●</span> <span class="t-bar-y">▒</span>
-                                <span class="t-bar-y">▒</span> <span class="t-bar-o">░</span>
-                                <span class="t-bar-o">●</span> <span class="t-bar-r">░</span>
-                            </div>
-                            <div class="t-muted">
-                                2,810 │ <span class="t-bar-g">●</span>
-                                <span class="t-bar-g">▒</span> <span class="t-bar-g">●</span>
-                                <span class="t-bar-y">░</span> <span class="t-bar-y">░</span>
-                                <span class="t-bar-o">░</span> <span class="t-bar-o">▒</span>
-                                <span class="t-bar-r">░</span> <span class="t-bar-o">●</span>
-                            </div>
-                            <div class="t-muted">
-                                0 │<span class="t-bar-g"
-                                    >●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●</span
-                                >
-                            </div>
-                            <div class="t-muted">└──────────────────────────────────────────</div>
-                            <div class="t-muted">10:12 11:08 12:30</div>
-                            <br />
-                            <div class="t-h2">Model Intelligence (MI) Over Time</div>
-                            <div class="t-muted">Calibrated against MRCR v2 8-needle benchmark</div>
-                            <br />
-                            <div class="t-muted">1.00 │<span class="t-bar-g">●●</span></div>
-                            <div class="t-muted">0.90 │ <span class="t-bar-g">●●●</span></div>
-                            <div class="t-muted">0.80 │ <span class="t-bar-g">●●●</span></div>
-                            <div class="t-muted">0.70 │ <span class="t-bar-y">●●●</span></div>
-                            <div class="t-muted">
-                                0.61 │ <span class="t-bar-y">●</span
-                                ><span style="color: #ef4444">▼</span
-                                ><span class="t-muted" style="font-size: 11px">
-                                    compact (⚠ lossy)</span
-                                >
-                            </div>
-                            <div class="t-muted">1.00 │ <span class="t-bar-g">●●</span></div>
-                            <div class="t-muted">0.80 │ <span class="t-bar-g">●●●</span></div>
-                            <div class="t-muted">0.70 │ <span class="t-bar-y">●●</span></div>
-                            <div class="t-muted">└──────────────────────────────────────────</div>
-                            <div class="t-muted">step 1 ▼ compact step 14</div>
-                            <br />
-                            <div class="t-h2">Cache Activity</div>
-                            <div class="t-muted">Creation ░ Read ▓</div>
-                            <br />
-                            <div class="t-muted">
-                                3│ <span class="t-cyan">░░░░░░░░▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓</span>
-                            </div>
-                            <div class="t-muted">
-                                2│ <span class="t-cyan">░░░░░░░░░░░░▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓</span>
-                            </div>
-                            <div class="t-muted">
-                                1│ <span class="t-cyan">░░░░░░░░░░░░░░░░▓▓▓▓▓▓▓▓▓▓▓▓</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Sessions tab -->
-                <div id="tab-sessions" class="tab-panel">
-                    <div class="example-terminal">
-                        <div class="example-terminal-body">
-                            <div>
-                                <span class="t-prompt">$ </span
-                                ><span class="t-cmd">context-stats sessions</span>
-                            </div>
-                            <br />
-                            <div class="t-h1">
-                                Recent Sessions <span class="t-muted">(last 5 min)</span>
-                            </div>
-                            <br />
-                            <div>
-                                <span class="t-cyan">43b5ed93-e7a3-44d9-9d58-bd35911f17e9</span>
-                            </div>
-                            <div>
-                                <span class="t-green">my-project</span>
-                                <span class="t-muted">·</span>
-                                <span class="t-muted">claude-opus-4-6[1m]</span>
-                                <span class="t-muted">·</span> 59K tokens
-                                <span class="t-muted">· 1m 55s ago</span>
-                            </div>
-                            <br />
-                            <div>
-                                <span class="t-cyan">66c00dcb-ebf6-4ed0-872e-23a60d715d60</span>
-                            </div>
-                            <div>
-                                <span class="t-green">api-server</span>
-                                <span class="t-muted">·</span>
-                                <span class="t-muted">claude-opus-4-6[1m]</span>
-                                <span class="t-muted">·</span> 83K tokens
-                                <span class="t-muted">· 4m 52s ago</span>
-                            </div>
-                            <br />
-                            <div class="t-muted">
-                                Tip: context-stats 43b5ed93-e7a3-44d9-9d58-bd35911f17e9 graph
-                            </div>
-                            <br />
-                            <div>
-                                <span class="t-prompt">$ </span
-                                ><span class="t-cmd">context-stats sessions --minutes 30</span>
-                            </div>
-                            <br />
-                            <div class="t-h1">
-                                Recent Sessions <span class="t-muted">(last 30 min)</span>
-                            </div>
-                            <br />
-                            <div>
-                                <span class="t-cyan">43b5ed93-e7a3-44d9-9d58-bd35911f17e9</span>
-                            </div>
-                            <div>
-                                <span class="t-green">my-project</span>
-                                <span class="t-muted">·</span>
-                                <span class="t-muted">claude-opus-4-6[1m]</span>
-                                <span class="t-muted">·</span> 59K tokens
-                                <span class="t-muted">· 1m 55s ago</span>
-                            </div>
-                            <br />
-                            <div>
-                                <span class="t-cyan">66c00dcb-ebf6-4ed0-872e-23a60d715d60</span>
-                            </div>
-                            <div>
-                                <span class="t-green">api-server</span>
-                                <span class="t-muted">·</span>
-                                <span class="t-muted">claude-opus-4-6[1m]</span>
-                                <span class="t-muted">·</span> 83K tokens
-                                <span class="t-muted">· 4m 52s ago</span>
-                            </div>
-                            <br />
-                            <div>
-                                <span class="t-cyan">a1b2c3d4-e5f6-7890-abcd-ef1234567890</span>
-                            </div>
-                            <div>
-                                <span class="t-green">docs-site</span>
-                                <span class="t-muted">·</span>
-                                <span class="t-muted">claude-sonnet-4-6</span>
-                                <span class="t-muted">·</span> 142K tokens
-                                <span class="t-muted">· 18m ago</span>
-                            </div>
-                            <br />
-                            <div class="t-muted">
-                                Tip: context-stats 43b5ed93-e7a3-44d9-9d58-bd35911f17e9 graph
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Export tab -->
-                <div id="tab-export" class="tab-panel">
-                    <div class="example-terminal">
-                        <div class="example-terminal-body">
-                            <div>
-                                <span class="t-prompt">$ </span
-                                ><span class="t-cmd">context-stats export abc-1234</span>
-                            </div>
-                            <div class="t-green">Exported → session-abc-1234-2026-04-07.md</div>
-                            <br />
-                            <div class="t-h1"># Session Export — abc-1234</div>
-                            <div class="t-muted">
-                                Generated: 2026-04-07 12:30:15 | context-stats v1.22.0
-                            </div>
-                            <br />
-                            <div class="t-h2">## Executive Summary</div>
-                            <br />
-                            <div class="t-muted">| Metric | Value |</div>
-                            <div class="t-muted">
-                                |---------------------|------------------------|
-                            </div>
-                            <div>
-                                <span class="t-key"> | Model | </span
-                                ><span class="t-cyan">Claude Opus 4.6</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Duration | </span
-                                ><span class="t-val">2h 18m 03s</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Interactions | </span
-                                ><span class="t-val">14</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Peak Context Used | </span
-                                ><span class="t-orange">112,000 / 200,000 (56%)</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Final MI Score | </span
-                                ><span class="t-yellow">0.712</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Total Cost | </span
-                                ><span class="t-money">$0.2847</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Cache Hit Ratio | </span
-                                ><span class="t-green">63.4%</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Git Branch | </span
-                                ><span class="t-indigo">feat/landing-page</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Lines Changed | </span
-                                ><span class="t-val">+284 / -41</span> |
-                            </div>
-                            <br />
-                            <div class="t-h2">## Interaction Timeline</div>
-                            <br />
-                            <div class="t-muted">
-                                | Step | Time | Context Used | Free | MI | Delta | Zone |
-                            </div>
-                            <div class="t-muted">
-                                |------|-------|--------------|---------|-------|---------|-------------|
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 1 | 10:12 | </span
-                                ><span class="t-green"> 18,240</span
-                                ><span class="t-muted"> | 181,760 | </span
-                                ><span class="t-green">0.982</span
-                                ><span class="t-muted"> | +18,240 | </span
-                                ><span class="t-green">Planning</span
-                                ><span class="t-muted"> |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 2 | 10:24 | </span
-                                ><span class="t-green"> 24,610</span
-                                ><span class="t-muted"> | 175,390 | </span
-                                ><span class="t-green">0.971</span
-                                ><span class="t-muted"> | +6,370 | </span
-                                ><span class="t-green">Planning</span
-                                ><span class="t-muted"> |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 5 | 10:58 | </span
-                                ><span class="t-green"> 61,340</span
-                                ><span class="t-muted"> | 138,660 | </span
-                                ><span class="t-green">0.894</span
-                                ><span class="t-muted"> | +8,100 | </span
-                                ><span class="t-green">Planning</span
-                                ><span class="t-muted"> |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 8 | 11:22 | </span
-                                ><span class="t-yellow"> 84,920</span
-                                ><span class="t-muted"> | 115,080 | </span
-                                ><span class="t-yellow">0.812</span
-                                ><span class="t-muted"> | +5,280 | </span
-                                ><span class="t-yellow">Code-only</span
-                                ><span class="t-muted"> |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 11 | 11:51 | </span
-                                ><span class="t-yellow"> 99,480</span
-                                ><span class="t-muted"> | 100,520 | </span
-                                ><span class="t-yellow">0.764</span
-                                ><span class="t-muted"> | +4,100 | </span
-                                ><span class="t-yellow">Code-only</span
-                                ><span class="t-muted"> |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 14 | 12:30 | </span
-                                ><span class="t-orange">112,000</span
-                                ><span class="t-muted"> | 88,000 | </span
-                                ><span class="t-yellow">0.712</span
-                                ><span class="t-muted"> | +3,140 | </span
-                                ><span class="t-yellow">Code-only</span
-                                ><span class="t-muted"> |</span>
-                            </div>
-                            <br />
-                            <div class="t-h2">## Cache Analysis</div>
-                            <br />
-                            <div>
-                                <span class="t-key"> Cache creation tokens: </span
-                                ><span class="t-val">28,400</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Cache read tokens: </span
-                                ><span class="t-green">49,120</span>
-                                <span class="t-muted">(63.4% hit rate)</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Cache savings: </span
-                                ><span class="t-money">~$0.087</span>
-                                <span class="t-muted">(vs. uncached)</span>
-                            </div>
-                            <br />
-                            <div class="t-muted">```mermaid</div>
-                            <div class="t-muted">pie title Cache Efficiency</div>
-                            <div class="t-muted">"Cache Hit" : 63.4</div>
-                            <div class="t-muted">"Fresh tokens" : 36.6</div>
-                            <div class="t-muted">```</div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Report tab -->
-                <div id="tab-report" class="tab-panel">
-                    <div class="example-terminal">
-                        <div class="example-terminal-body">
-                            <div>
-                                <span class="t-prompt">$ </span
-                                ><span class="t-cmd">context-stats report --since-days 30</span>
-                            </div>
-                            <div class="t-green">Analyzing 312 sessions across 18 projects...</div>
-                            <br />
-                            <div class="t-h1"># Token Usage Analytics Report</div>
-                            <div class="t-muted">
-                                Generated: 2026-04-07 12:00:00 | context-stats v1.22.0
-                            </div>
-                            <br />
-                            <div class="t-h2">## Executive Summary (last 30 days)</div>
-                            <br />
-                            <div class="t-muted">| Metric | Value |</div>
-                            <div class="t-muted">
-                                |-------------------------|-------------------------------|
-                            </div>
-                            <div>
-                                <span class="t-key"> | Total Spend | </span
-                                ><span class="t-money">$1,842.35</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Total Sessions | </span
-                                ><span class="t-val">312</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Projects Analyzed | </span
-                                ><span class="t-val">18</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Cache Hit Ratio | </span
-                                ><span class="t-green">41.2%</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Avg Session Cost | </span
-                                ><span class="t-val">$5.90</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Avg Session Duration | </span
-                                ><span class="t-val">3h 22m 14s</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Most Expensive Session | </span
-                                ><span class="t-orange">a3f9c12d… ($87.40, 4.7%)</span> |
-                            </div>
-                            <div>
-                                <span class="t-key"> | Most Expensive Project | </span
-                                ><span class="t-orange">project-alpha ($412.80, 22.4%)</span> |
-                            </div>
-                            <br />
-                            <div class="t-h2">## Model Usage</div>
-                            <br />
-                            <div class="t-muted">| Model | Sessions | Cost | % Total |</div>
-                            <div class="t-muted">|--------|----------|------------|---------|</div>
-                            <div>
-                                <span class="t-muted"> | </span><span class="t-indigo">opus </span
-                                ><span class="t-muted"> | 241 | </span
-                                ><span class="t-money">$1,512.30</span
-                                ><span class="t-muted"> | 82.1% |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | </span><span class="t-cyan">sonnet</span
-                                ><span class="t-muted"> | 42 | </span
-                                ><span class="t-money">$218.75</span
-                                ><span class="t-muted"> | 11.9% |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | </span><span class="t-yellow">haiku </span
-                                ><span class="t-muted"> | 29 | </span
-                                ><span class="t-money">$111.30</span
-                                ><span class="t-muted"> | 6.0% |</span>
-                            </div>
-                            <br />
-                            <div class="t-h2">## Weekly Spend Trend</div>
-                            <br />
-                            <div>
-                                <span class="t-muted"> W10 </span
-                                ><span class="t-bar-g">███████████</span
-                                ><span class="t-muted"> $284.50 (48 sessions)</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> W11 </span
-                                ><span class="t-bar-y">████████████████</span
-                                ><span class="t-muted"> $412.80 (74 sessions)</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> W12 </span
-                                ><span class="t-bar-y">█████████████</span
-                                ><span class="t-muted"> $348.20 (68 sessions)</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> W13 </span
-                                ><span class="t-bar-o">████████████████████</span
-                                ><span class="t-muted"> $489.60 (82 sessions) ← peak</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> W14 </span
-                                ><span class="t-bar-g">████████</span
-                                ><span class="t-muted"> $218.75 (31 sessions)</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> W15 </span><span class="t-bar-g">███</span
-                                ><span class="t-muted"> $88.50 (9 sessions)</span>
-                            </div>
-                            <br />
-                            <div class="t-h2">## Top Projects by Cost</div>
-                            <br />
-                            <div class="t-muted">
-                                | # | Project | Sessions | Cost | Cache % | Dominant |
-                            </div>
-                            <div class="t-muted">
-                                |---|-----------------|----------|-----------|----------|----------|
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 1 | project-alpha | 28 | </span
-                                ><span class="t-red">$412.80</span><span class="t-muted"> | </span
-                                ><span class="t-orange">12.0%</span
-                                ><span class="t-muted"> | opus |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 2 | project-beta | 41 | </span
-                                ><span class="t-orange">$318.44</span
-                                ><span class="t-muted"> | </span><span class="t-yellow">44.1%</span
-                                ><span class="t-muted"> | opus |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 3 | project-gamma | 35 | </span
-                                ><span class="t-orange">$264.17</span
-                                ><span class="t-muted"> | </span><span class="t-yellow">38.4%</span
-                                ><span class="t-muted"> | opus |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 4 | project-delta | 27 | </span
-                                ><span class="t-yellow">$198.53</span
-                                ><span class="t-muted"> | </span><span class="t-green">49.2%</span
-                                ><span class="t-muted"> | opus |</span>
-                            </div>
-                            <div>
-                                <span class="t-muted"> | 5 | project-epsilon | 22 | </span
-                                ><span class="t-yellow">$187.62</span
-                                ><span class="t-muted"> | </span><span class="t-yellow">31.0%</span
-                                ><span class="t-muted"> | opus |</span>
-                            </div>
-                            <br />
-                            <div class="t-h2">## Activity by Day of Week</div>
-                            <br />
-                            <div>
-                                <span class="t-key"> Mon </span
-                                ><span class="t-bar-g">############</span
-                                ><span class="t-muted">........ 52 sessions</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Tue </span
-                                ><span class="t-bar-g">##################</span
-                                ><span class="t-muted">... 68 sessions</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Wed </span
-                                ><span class="t-bar-g">####################</span
-                                ><span class="t-muted"> 71 sessions ← busiest</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Thu </span
-                                ><span class="t-bar-g">############</span
-                                ><span class="t-muted">........ 48 sessions</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Fri </span
-                                ><span class="t-bar-g">###############</span
-                                ><span class="t-muted">..... 55 sessions</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Sat </span><span class="t-bar-d">######</span
-                                ><span class="t-muted">.............. 22 sessions</span>
-                            </div>
-                            <div>
-                                <span class="t-key"> Sun </span><span class="t-bar-d">#######</span
-                                ><span class="t-muted">............. 26 sessions</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <script>
-            function switchTab(e, panelId) {
-                const section = e.target.closest('section');
-                section.querySelectorAll('.tab-btn').forEach(b => {
-                    b.classList.remove('active', 'green');
-                    b.style.borderBottomColor = 'transparent';
-                    b.style.color = '';
-                });
-                section.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
-                e.target.classList.add('active');
-                if (panelId === 'tab-graph') {
-                    e.target.classList.add('green');
-                } else if (panelId === 'tab-sessions') {
-                    e.target.style.color = 'var(--cyan)';
-                    e.target.style.borderBottomColor = 'var(--cyan)';
-                } else if (panelId === 'tab-report') {
-                    e.target.style.color = 'var(--indigo)';
-                    e.target.style.borderBottomColor = 'var(--indigo)';
-                }
-                document.getElementById(panelId).classList.add('active');
-            }
-        </script>
-
-        <!-- ── SCREENSHOTS ────────────────────────────────────────────── -->
-        <section id="screenshots">
-            <div class="container">
-                <span class="section-label">See It In Action</span>
-                <h2>Every context state, visualized.</h2>
-                <p class="lead">
-                    Color-coded zones tell you exactly what to do — no guesswork required.
-                </p>
-
-                <div class="screenshots-grid">
-                    <div class="screenshot-card">
-                        <img
-                            src="images/1.12.0/plan-zone.png"
-                            alt="Planning zone — green, plenty of context"
-                            loading="lazy"
-                            width="600"
-                            height="400"
-                        />
-                        <div class="screenshot-caption">
-                            Planning Zone — plenty of context, keep working
-                        </div>
-                    </div>
-                    <div class="screenshot-card">
-                        <img
-                            src="images/1.12.0/code-zone.png"
-                            alt="Code-only zone — yellow, context tightening"
-                            loading="lazy"
-                            width="600"
-                            height="400"
-                        />
-                        <div class="screenshot-caption">
-                            Code-Only Zone — tightening, finish current task
-                        </div>
-                    </div>
-                    <div class="screenshot-card">
-                        <img
-                            src="images/1.12.0/dump-zone.png"
-                            alt="Dump zone — orange, quality declining"
-                            loading="lazy"
-                            width="600"
-                            height="400"
-                        />
-                        <div class="screenshot-caption">
-                            Dump Zone — quality declining, wrap up now
-                        </div>
-                    </div>
-                    <div class="screenshot-card">
-                        <img
-                            src="images/token-graph.png"
-                            alt="Live ASCII graph dashboard — context-stats graph command output"
-                            loading="lazy"
-                            width="600"
-                            height="400"
-                        />
-                        <div class="screenshot-caption">
-                            Live ASCII graph dashboard — <code>context-stats graph</code>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- ── ZONES ─────────────────────────────────────────────────── -->
-        <section id="zones">
-            <div class="container">
-                <div style="text-align: center">
-                    <span class="section-label">Context Zones</span>
-                    <h2>Five zones. One clear action each.</h2>
-                    <p class="lead" style="margin: 0 auto 0">
-                        context-stats maps token usage to five zones so you always know what to do
-                        next.
+                <div class="section-head">
+                    <span class="section-label">What you get</span>
+                    <h2>Three levels of analytics,<br />one lightweight tool.</h2>
+                    <p>
+                        From the live statusline in front of you to multi-week cost reports —
+                        each level answers a different question about how you use Claude Code.
                     </p>
                 </div>
 
-                <div class="zones-list">
-                    <div class="zone-row">
-                        <span
-                            class="zone-dot"
-                            style="background: #10b981; box-shadow: 0 0 8px #10b981"
-                        ></span>
-                        <span class="zone-name" style="color: #10b981">Planning</span>
-                        <span class="zone-action"
-                            >Plenty of room — keep planning and coding freely<br /><span
-                                style="
-                                    font-size: 12px;
-                                    color: var(--text-muted);
-                                    font-style: italic;
-                                "
-                                >→ Plan ahead, explore options, read large files freely</span
-                            ></span
-                        >
-                        <span
-                            class="zone-pct"
-                            style="background: rgba(16, 185, 129, 0.12); color: #10b981"
-                            >&lt;25%</span
-                        >
+                <div class="levels">
+                    <div class="level-card green">
+                        <span class="level-tag">Level 1 · Live</span>
+                        <h3>Real-time statusline</h3>
+                        <p>
+                            Context zone, Model Intelligence score, and token delta on every
+                            prompt — so you act now, not after the context is already gone.
+                        </p>
+                        <code>context-stats graph</code>
                     </div>
-                    <div class="zone-row">
-                        <span
-                            class="zone-dot"
-                            style="background: #f59e0b; box-shadow: 0 0 8px #f59e0b"
-                        ></span>
-                        <span class="zone-name" style="color: #f59e0b">Code-only</span>
-                        <span class="zone-action"
-                            >Context tightening — finish current task, skip exploration<br /><span
-                                style="
-                                    font-size: 12px;
-                                    color: var(--text-muted);
-                                    font-style: italic;
-                                "
-                                >→ Avoid new file reads; complete what's in progress</span
-                            ></span
-                        >
-                        <span
-                            class="zone-pct"
-                            style="background: rgba(245, 158, 11, 0.12); color: #f59e0b"
-                            >25–40%</span
-                        >
+                    <div class="level-card cyan">
+                        <span class="level-tag">Level 2 · Session</span>
+                        <h3>Per-session deep dive</h3>
+                        <p>
+                            Export a full session to Markdown: cache efficiency, interaction
+                            timeline, zone history, and the exact moments context compacted.
+                        </p>
+                        <code>context-stats export</code>
                     </div>
-                    <div class="zone-row">
-                        <span
-                            class="zone-dot"
-                            style="background: #f97316; box-shadow: 0 0 8px #f97316"
-                        ></span>
-                        <span class="zone-name" style="color: #f97316">Dump</span>
-                        <span class="zone-action"
-                            >Quality declining — wrap up, prepare to export context<br /><span
-                                style="
-                                    font-size: 12px;
-                                    color: var(--text-muted);
-                                    font-style: italic;
-                                "
-                                >→ Wrap up task, export session, prepare new context</span
-                            ></span
-                        >
-                        <span
-                            class="zone-pct"
-                            style="background: rgba(249, 115, 22, 0.12); color: #f97316"
-                            >40–70%</span
-                        >
-                    </div>
-                    <div class="zone-row">
-                        <span
-                            class="zone-dot"
-                            style="background: #ef4444; box-shadow: 0 0 8px #ef4444"
-                        ></span>
-                        <span class="zone-name" style="color: #ef4444">ExDump</span>
-                        <span class="zone-action"
-                            >Near hard limit — start a new session immediately<br /><span
-                                style="
-                                    font-size: 12px;
-                                    color: var(--text-muted);
-                                    font-style: italic;
-                                "
-                                >→ Stop work, start a fresh session now</span
-                            ></span
-                        >
-                        <span
-                            class="zone-pct"
-                            style="background: rgba(239, 68, 68, 0.12); color: #ef4444"
-                            >70–75%</span
-                        >
-                    </div>
-                    <div class="zone-row">
-                        <span class="zone-dot" style="background: #64748b"></span>
-                        <span class="zone-name" style="color: #64748b">Dead</span>
-                        <span class="zone-action"
-                            >Context exhausted — stop, nothing productive remains<br /><span
-                                style="
-                                    font-size: 12px;
-                                    color: var(--text-muted);
-                                    font-style: italic;
-                                "
-                                >→ Start a new session immediately</span
-                            ></span
-                        >
-                        <span
-                            class="zone-pct"
-                            style="background: rgba(100, 116, 139, 0.12); color: #64748b"
-                            >&gt;75%</span
-                        >
+                    <div class="level-card indigo">
+                        <span class="level-tag">Level 3 · Report</span>
+                        <h3>Multi-week analytics</h3>
+                        <p>
+                            Cost breakdown, cache analysis, and cross-project patterns over weeks
+                            or months — so you know exactly where your tokens go.
+                        </p>
+                        <code>context-stats report</code>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- ── STATUSLINE PREVIEW ─────────────────────────────────────── -->
-        <section id="statusline-preview">
+        <!-- ── DETAIL BANNER ────────────────────────────────────── -->
+        <section style="padding-top: 0">
             <div class="container">
-                <div style="text-align: center">
-                    <span class="section-label">Statusline Preview</span>
-                    <h2>What you see at every context zone.</h2>
-                    <p class="lead" style="margin: 0 auto 0">
-                        The statusline updates live after each prompt. Here's exactly what it shows
-                        across all five zones.
-                    </p>
-                </div>
-
-                <!-- Thresholds from src/claude_statusline/graphs/intelligence.py (200k standard model):
-         dump_zone  = 200k × 0.40 = 80,000 used
-         warn_start = 80,000 − 30,000 = 50,000 used  ← Plan/Code boundary
-         hard_limit = 200k × 0.70 = 140,000 used     ← Dump/ExDump boundary
-         dead_zone  = 200k × 0.75 = 150,000 used     ← ExDump/Dead boundary
-         Plan:   used < 50,000          (< 25%)
-         Code:   50,000 ≤ used < 80,000 (25–40%)
-         Dump:   80,000 ≤ used < 140,000 (40–70%)
-         ExDump: 140,000 ≤ used < 150,000 (70–75%)
-         Dead:   used ≥ 150,000          (≥ 75%)
-    -->
-
-                <div class="sl-grid">
-                    <!-- Plan: used < 50,000 on 200k model -->
-                    <div class="sl-zone-block">
-                        <div class="sl-zone-label">
-                            <span
-                                class="sl-dot"
-                                style="background: #10b981; box-shadow: 0 0 6px #10b981"
-                            ></span>
-                            <span style="color: #10b981">Plan</span>
-                            <span
-                                style="
-                                    color: var(--text-muted);
-                                    font-weight: 400;
-                                    margin-left: auto;
-                                "
-                                >used &lt; 50,000 &nbsp;·&nbsp; &lt; 25% used</span
-                            >
-                        </div>
-                        <div class="sl-terminal">
-                            <span style="color: #06b6d4">my-project</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #c084fc">main [2]</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #10b981">32,480 (16.2%)</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #10b981">Plan</span
-                            ><span style="color: var(--text-muted)">
-                                | Opus 4.6 (200k context) | </span
-                            ><span style="color: #475569"
-                                >76f0c6e5-47e1-4656-9ffe-59ba12005967</span
-                            >
-                            <div style="margin-top: 8px; color: var(--text-muted); font-size: 11px">
-                                → Plenty of room. Keep planning and coding freely.
-                            </div>
-                        </div>
+                <div class="detail-banner">
+                    <div>
+                        <h3>Want the full picture?</h3>
+                        <p>
+                            Terminal walkthroughs, the five context zones, Model Intelligence,
+                            cache keep-warm, configuration, and every command — all in one place.
+                        </p>
                     </div>
-
-                    <!-- Code: 50,000 ≤ used < 80,000 on 200k model -->
-                    <div class="sl-zone-block">
-                        <div class="sl-zone-label">
-                            <span
-                                class="sl-dot"
-                                style="background: #f59e0b; box-shadow: 0 0 6px #f59e0b"
-                            ></span>
-                            <span style="color: #f59e0b">Code</span>
-                            <span
-                                style="
-                                    color: var(--text-muted);
-                                    font-weight: 400;
-                                    margin-left: auto;
-                                "
-                                >50,000 ≤ used &lt; 80,000 &nbsp;·&nbsp; 25–40% used</span
-                            >
-                        </div>
-                        <div class="sl-terminal">
-                            <span style="color: #06b6d4">my-project</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #c084fc">feat/new-ui [5]</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #f59e0b">65,210 (32.6%)</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #f59e0b">Code</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #06b6d4">+494</span
-                            ><span style="color: var(--text-muted)">
-                                | Opus 4.6 (200k context) | </span
-                            ><span style="color: #475569"
-                                >e43c4908-3374-46e5-b8e4-73ab96e42d0f</span
-                            >
-                            <div style="margin-top: 8px; color: var(--text-muted); font-size: 11px">
-                                → Context tightening. Finish current task, skip exploration.
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Dump: 80,000 ≤ used < 140,000 on 200k model -->
-                    <div class="sl-zone-block">
-                        <div class="sl-zone-label">
-                            <span
-                                class="sl-dot"
-                                style="background: #f97316; box-shadow: 0 0 6px #f97316"
-                            ></span>
-                            <span style="color: #f97316">Dump</span>
-                            <span
-                                style="
-                                    color: var(--text-muted);
-                                    font-weight: 400;
-                                    margin-left: auto;
-                                "
-                                >80,000 ≤ used &lt; 140,000 &nbsp;·&nbsp; 40–70% used</span
-                            >
-                        </div>
-                        <div class="sl-terminal">
-                            <span style="color: #06b6d4">my-project</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #c084fc">fix/bug-123 [8]</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #f97316">112,640 (56.3%)</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #f97316">Dump</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #06b6d4">+198</span
-                            ><span style="color: var(--text-muted)">
-                                | Opus 4.6 (200k context) | </span
-                            ><span style="color: #475569"
-                                >c58eab6e-9fd9-4a99-8fee-8de07b566b9a</span
-                            >
-                            <div style="margin-top: 8px; color: var(--text-muted); font-size: 11px">
-                                → Quality declining. Wrap up now, prepare to export context.
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- ExDump: 140,000 ≤ used < 150,000 on 200k model -->
-                    <div class="sl-zone-block">
-                        <div class="sl-zone-label">
-                            <span
-                                class="sl-dot"
-                                style="background: #ef4444; box-shadow: 0 0 6px #ef4444"
-                            ></span>
-                            <span style="color: #ef4444">ExDump</span>
-                            <span
-                                style="
-                                    color: var(--text-muted);
-                                    font-weight: 400;
-                                    margin-left: auto;
-                                "
-                                >140,000 ≤ used &lt; 150,000 &nbsp;·&nbsp; 70–75% used</span
-                            >
-                        </div>
-                        <div class="sl-terminal">
-                            <span style="color: #06b6d4">my-project</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #c084fc">fix/bug-123 [12]</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #ef4444">144,380 (72.2%)</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #ef4444">ExDump</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #06b6d4">+1,240</span
-                            ><span style="color: var(--text-muted)">
-                                | Opus 4.6 (200k context) | </span
-                            ><span style="color: #475569"
-                                >d4e5f6a7-b8c9-0123-defa-234567890123</span
-                            >
-                            <div style="margin-top: 8px; color: var(--text-muted); font-size: 11px">
-                                → Near hard limit. Start a new session immediately.
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Dead: used ≥ 150,000 on 200k model -->
-                    <div class="sl-zone-block">
-                        <div class="sl-zone-label">
-                            <span class="sl-dot" style="background: #64748b"></span>
-                            <span style="color: #64748b">Dead</span>
-                            <span
-                                style="
-                                    color: var(--text-muted);
-                                    font-weight: 400;
-                                    margin-left: auto;
-                                "
-                                >used ≥ 150,000 &nbsp;·&nbsp; ≥ 75% used</span
-                            >
-                        </div>
-                        <div class="sl-terminal">
-                            <span style="color: #06b6d4">my-project</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #c084fc">fix/bug-123 [15]</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #64748b">158,920 (79.5%)</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #64748b">Dead</span
-                            ><span style="color: var(--text-muted)"> | </span
-                            ><span style="color: #06b6d4">+320</span
-                            ><span style="color: var(--text-muted)">
-                                | Opus 4.6 (200k context) | </span
-                            ><span style="color: #475569"
-                                >e5f6a7b8-c9d0-1234-efab-345678901234</span
-                            >
-                            <div style="margin-top: 8px; color: var(--text-muted); font-size: 11px">
-                                → Context exhausted. Stop — nothing productive remains.
-                            </div>
-                        </div>
-                    </div>
+                    <a href="docs.html" class="btn-primary">Open the documentation →</a>
                 </div>
             </div>
         </section>
 
-        <!-- ── HOW IT WORKS ───────────────────────────────────────────── -->
-        <section id="how-it-works">
-            <div class="container">
-                <span class="section-label">Get Started</span>
-                <h2>Up and running in 60 seconds.</h2>
-                <p class="lead">No config files. No sign-up. No data leaving your machine.</p>
-
-                <div class="steps">
-                    <div class="step">
-                        <div class="step-num">1</div>
-                        <div class="step-body">
-                            <h3>Install the package</h3>
-                            <p>One pip command, zero dependencies.</p>
-                            <code>pip install context-stats</code>
-                        </div>
-                    </div>
-                    <div class="step-arrow">↓</div>
-                    <div class="step">
-                        <div class="step-num">2</div>
-                        <div class="step-body">
-                            <h3>Configure Claude Code</h3>
-                            <p>Add the status line to <code>~/.claude/settings.json</code>.</p>
-                            <code style="white-space: pre"
-                                >{ "statusLine": { "type": "command", "command": "claude-statusline"
-                                } }</code
-                            >
-                        </div>
-                    </div>
-                    <div class="step-arrow">↓</div>
-                    <div class="step">
-                        <div class="step-num">3</div>
-                        <div class="step-body">
-                            <h3>Start a session</h3>
-                            <p>
-                                Your status line is live. Context zone, MI score, token delta — all
-                                visible.
-                            </p>
-                            <code>claude # or open Claude Code</code>
-                        </div>
-                    </div>
-                    <div class="step-arrow">↓</div>
-                    <div class="step">
-                        <div class="step-num">4</div>
-                        <div class="step-body">
-                            <h3>Explore & analyze</h3>
-                            <p>Use any of these commands any time — no session ID needed.</p>
-                            <code style="white-space: pre"
-                                ># Live ASCII dashboard — context, MI, cache, delta context-stats
-                                graph # List recent sessions (last 5 min by default) context-stats
-                                sessions context-stats sessions --minutes 30 # Keep the prompt cache
-                                alive during idle gaps context-stats cache-warm on # Export full
-                                session report to Markdown context-stats export # Multi-project
-                                analytics (last 30 days) context-stats report --since-days 30 #
-                                Explain raw JSON from Claude Code stdin context-stats explain</code
-                            >
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- ── FAQ ───────────────────────────────────────────────────── -->
-        <section id="faq">
-            <div class="container">
-                <div style="text-align: center">
-                    <span class="section-label">FAQ</span>
-                    <h2>Common questions</h2>
-                </div>
-
-                <div class="faq-list">
-                    <details>
-                        <summary>Does context-stats send any data to the cloud?</summary>
-                        <p>
-                            No. All session data stays local in <code>~/.claude/statusline/</code>.
-                            There are no network requests, no telemetry, no external API calls of
-                            any kind. Your token usage and session data never leave your machine.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>Will it slow down my Claude Code sessions?</summary>
-                        <p>
-                            No. The statusline script is a lightweight Python process that runs
-                            synchronously on each prompt. It reads from local CSV files and writes a
-                            single line to stdout. Typical execution is under 10ms. Git operations
-                            have a 5-second timeout to prevent hangs.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>Does it work on Windows?</summary>
-                        <p>
-                            Yes. context-stats is pure Python 3.9+ with zero external dependencies
-                            and runs on macOS, Linux, and Windows. The statusline script and CLI
-                            both work across all platforms.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>What Python version do I need?</summary>
-                        <p>
-                            Python 3.9 or higher. No external packages are required — context-stats
-                            uses only the Python standard library.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>Can I customize the colors and display?</summary>
-                        <p>
-                            Yes. Create <code>~/.claude/statusline.conf</code> with key=value pairs.
-                            You can customize 18 named colors or use hex codes, toggle MI display,
-                            token detail, delta tracking, session ID, motion effects, and more. Full
-                            configuration reference in the docs.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>How accurate are the token counts?</summary>
-                        <p>
-                            context-stats reads the token data directly from Claude Code's status
-                            line JSON. It does not estimate — it reports the exact values that
-                            Claude Code provides. The MI score is calibrated against the MRCR v2
-                            8-needle benchmark.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>
-                            What's the difference between the statusline and the graph dashboard?
-                        </summary>
-                        <p>
-                            The statusline (<code>claude-statusline</code>) is the persistent
-                            one-line display shown by Claude Code at each prompt — it's always on.
-                            The graph dashboard (<code>context-stats graph</code>) is an on-demand
-                            ASCII chart view you run manually to see usage history, MI trends, cache
-                            activity, and delta per interaction over the session.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>What is cache keep-warm and why do I need it?</summary>
-                        <p>
-                            Claude's prompt cache has a 5-minute TTL. Any pause longer than 5
-                            minutes — a code review, a coffee break, a long think before replying —
-                            silently evicts the cache. Your next request then pays full token price
-                            instead of the cached rate (roughly 10× cheaper for large contexts).
-                            <code>cache-warm</code> solves this by running a lightweight background
-                            heartbeat every 4 minutes, keeping the cache alive for up to 30 minutes
-                            (or a custom duration you specify). Start it with
-                            <code>context-stats &lt;session_id&gt; cache-warm on</code> from a
-                            separate terminal, and stop it with <code>cache-warm off</code>. The
-                            savings show up automatically in your
-                            <code>context-stats export</code> report.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>
-                            What is compaction detection and what does the ▼ marker mean?
-                        </summary>
-                        <p>
-                            When Claude Code compacts its context (a &gt;50% drop in token count
-                            between interactions), context-stats detects it automatically and marks
-                            the point with a <code>▼</code> symbol in your graphs. This tells you
-                            exactly when and where compaction occurred during a session. More
-                            importantly, it also captures the MI (Model Intelligence) score at that
-                            moment — if MI was below 0.6 when compaction happened, it flags the
-                            event as <em>potentially lossy</em>. A lossy compaction means Claude was
-                            already degraded when it summarized, so the summary may have dropped
-                            important details. You'll see this as
-                            <code>▼ compact (MI 0.61 ⚠ lossy)</code> in the graph output.
-                        </p>
-                    </details>
-
-                    <details>
-                        <summary>What are zone recommendations?</summary>
-                        <p>
-                            Each context zone (Planning, Code, Dump, ExDump, Dead) now comes with a
-                            brief actionable recommendation so you always know what to do next — no
-                            need to look anything up. For example, in the Dump zone you'll see
-                            <em>"Wrap up task, export session, prepare new context"</em>. These
-                            appear inline in the statusline output and in graph annotations.
-                        </p>
-                    </details>
-                </div>
-            </div>
-        </section>
-
-        <!-- ── FINAL CTA ──────────────────────────────────────────────── -->
+        <!-- ── FINAL CTA ────────────────────────────────────────── -->
         <section class="cta-section">
             <div class="container">
-                <span class="section-label">Get Started Free</span>
+                <span class="section-label">Get started free</span>
                 <h2>Stop flying blind.<br />Start every session with a map.</h2>
                 <p class="lead">
-                    Free. MIT licensed. Zero external dependencies.<br />
-                    All your data stays local — always.
+                    Free. MIT licensed. Zero external dependencies. All your data stays local —
+                    always.
                 </p>
 
                 <div class="hero-actions">
                     <a href="https://pypi.org/project/context-stats/" class="btn-primary">
-                        <svg
-                            width="16"
-                            height="16"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2.5"
-                        >
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                             <path d="M12 5v14M5 12l7 7 7-7" />
                         </svg>
                         pip install context-stats
                     </a>
                     <a href="https://github.com/luongnv89/context-stats" class="btn-secondary">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                            <path
-                                d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"
-                            />
+                            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
                         </svg>
                         Star on GitHub
                     </a>
@@ -3273,65 +904,29 @@
 
                 <div class="trust-badges">
                     <span class="badge">
-                        <svg
-                            width="14"
-                            height="14"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="var(--green)"
-                            stroke-width="2"
-                        >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2">
                             <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
                         </svg>
                         No data sent anywhere
                     </span>
                     <span class="badge">
-                        <svg
-                            width="14"
-                            height="14"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="var(--cyan)"
-                            stroke-width="2"
-                        >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--cyan)" stroke-width="2">
                             <circle cx="12" cy="12" r="10" />
                             <path d="M12 8v4l3 3" />
                         </svg>
                         Install in under 60s
                     </span>
                     <span class="badge">
-                        <svg
-                            width="14"
-                            height="14"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="var(--indigo)"
-                            stroke-width="2"
-                        >
-                            <path
-                                d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
-                            />
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--indigo)" stroke-width="2">
+                            <path d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
                         </svg>
                         MIT licensed, free forever
-                    </span>
-                    <span class="badge">
-                        <svg
-                            width="14"
-                            height="14"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="var(--yellow)"
-                            stroke-width="2"
-                        >
-                            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-                        </svg>
-                        Zero dependencies
                     </span>
                 </div>
             </div>
         </section>
 
-        <!-- ── FOOTER ────────────────────────────────────────────────── -->
+        <!-- ── FOOTER ───────────────────────────────────────────── -->
         <footer>
             <div class="container">
                 <div class="footer-inner">
@@ -3343,14 +938,10 @@
                         >
                     </div>
                     <ul class="footer-links">
+                        <li><a href="docs.html">Documentation</a></li>
                         <li><a href="https://pypi.org/project/context-stats/">PyPI</a></li>
                         <li><a href="https://github.com/luongnv89/context-stats">GitHub</a></li>
-                        <li>
-                            <a href="https://github.com/luongnv89/context-stats/issues">Issues</a>
-                        </li>
-                        <li>
-                            <a href="https://github.com/luongnv89/context-stats#readme">Docs</a>
-                        </li>
+                        <li><a href="https://github.com/luongnv89/context-stats/issues">Issues</a></li>
                     </ul>
                 </div>
             </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -12,6 +12,13 @@
   </url>
 
   <url>
+    <loc>https://luongnv89.github.io/context-stats/docs.html</loc>
+    <lastmod>2026-06-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
     <loc>https://luongnv89.github.io/context-stats/installation.html</loc>
     <lastmod>2026-06-11</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
Type: refactor

## Summary

A fresh brand and a cleaner site, in three parts.

### 🎨 New logo — "context window frame"
Replaces the three-arc mark with a literal **context window**: a rounded frame holding a green→cyan **fill gauge**, a cyan **cursor** marking current position, and an indigo **limit tick**. Keeps the existing palette (`#0F172A` slate · `#10B981` green · `#06B6D4` cyan · `#818CF8` indigo).

All 7 SVG variants regenerated from the canonical mark geometry (verified byte-identical across mark/full/icon/white/black), plus `brand-showcase.html`.

### 🧹 Rebuilt landing page (`docs/index.html`)
Clean, minimal, one-screen layout on the new brand palette:
- Hero with a real, fully-faithful statusline + graph terminal demo
- Live metrics bar — GitHub stars/forks + PyPI downloads (fetched) and product stats (3 levels, 5 zones, 0 network calls, 60s setup)
- Three-level feature cards + a single primary CTA
- Nav: bare mark + HTML `ContextStats` wordmark

### 📄 New dedicated docs page (`docs/docs.html`)
Full feature & usage guide: statusline, graph, export, report walkthroughs; the five context zones; Model Intelligence; cache keep-warm; compaction; and configuration. Added to `sitemap.xml`.

## Accuracy
Every terminal example and factual claim was aligned to **real CLI output and source code**, not invented:
- Statusline format matches the real render (`project | branch [n] | tokens (pct%) | zone | tok/s | model | session`)
- Zone labels + recommendations from `intelligence.py`
- MI thresholds (≥0.90 green, 0.80–0.90 yellow) and formula `MI = max(0, 1 − u^β)`
- cache-warm timing (~5min TTL, 4min interval, 30min default) and compaction (>50% drop, lossy below MI 0.6)

## Test plan
- [x] All 7 SVGs parse as valid XML; mark geometry identical across variants
- [x] Both HTML pages have balanced tags and resolve all referenced assets
- [ ] Visual review on light + dark backgrounds
- [ ] Confirm GitHub/PyPI metric fetches render on the deployed GitHub Pages site