### PR TITLE
feat: per-element structural colors for tps, delta, model, session

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,11 @@ Restart Claude Code. The status line, graph dashboard, session export, and repor
 color_project_name=bright_cyan
 color_branch_name=bright_magenta
 color_mi_score=#ff9e64
+# Each structural element can take its own color (else inherits color_separator):
+color_tps=#6ED7D2
+color_delta=#FFF8DC
+color_model=#C0C0C0
+color_session=#8B8682
 show_mi=true
 show_delta=true
 show_tps=true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,16 +52,21 @@ mi_curve_beta=1.5  # Override with custom beta for all models
 
 | Component     | Description              | Default Color | Config Key             |
 | ------------- | ------------------------ | ------------- | ---------------------- |
-| `[Opus 4.6]`  | Current AI model         | Dim           | `color_separator`      |
+| `[Opus 4.6]`  | Current AI model         | Dim           | `color_model`          |
 | `my-project`  | Current directory        | Cyan          | `color_project_name`   |
 | `main`        | Git branch               | Green         | `color_branch_name`    |
 | `[3]`         | Uncommitted changes      | Cyan          | `color_cyan`           |
 | `64,000 free` | Available tokens         | Bold White    | `color_context_length` |
 | `(32.0%)`     | Context usage percentage | -             | -                      |
-| `[+2,500]`    | Token delta              | Dim           | `color_separator`      |
+| `42.5 tok/s`  | Model throughput         | Dim           | `color_tps`            |
+| `[+2,500]`    | Token delta              | Dim           | `color_delta`          |
 | `MI:0.918`    | Model Intelligence score | Yellow        | `color_mi_score`       |
 | `[AC:45k]`    | Autocompact buffer       | Dim           | -                      |
-| `session_id`  | Current session          | Dim           | `color_separator`      |
+| `session_id`  | Current session          | Dim           | `color_session`        |
+
+The four structural elements — model, tok/s, delta, and session — default to
+`color_separator` when their own key is not set, so they can be colored together
+(via `color_separator`) or each given a distinct color.
 
 ## Token Colors
 
@@ -163,7 +168,13 @@ color_project_name=cyan           # Which project you're in
 color_branch_name=green           # Git branch at a glance
 color_mi_score=yellow             # MI score
 color_zone=default                # Zone indicator (uses zone color by default)
-color_separator=dim               # Model name, delta, session (visual structure)
+color_separator=dim               # tok/s, delta, model, session (visual structure)
+
+# Structural elements — each defaults to color_separator, override for distinct colors
+color_tps=#6ED7D2                 # Model throughput (tok/s)
+color_delta=#FFF8DC               # Token delta since last refresh
+color_model=#C0C0C0               # Model name
+color_session=#8B8682             # Session ID
 ```
 
 **Fallback chain:** Per-property key → base color key → built-in default. For example, if `color_project_name` is not set, the `color_blue` value is used (if set), otherwise the built-in default (cyan).

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -85,6 +85,10 @@ Each statusline element has its own configurable color with a fallback chain:
 | Git branch     | Green        | `color_branch_name`    | `color_magenta`    |
 | MI score       | Yellow       | `color_mi_score`       | MI-based color     |
 | Zone indicator | (zone color) | `color_zone`           | Dynamic zone color |
+| Model name     | Dim          | `color_model`          | `color_separator`  |
+| Throughput     | Dim          | `color_tps`            | `color_separator`  |
+| Token delta    | Dim          | `color_delta`          | `color_separator`  |
+| Session ID     | Dim          | `color_session`        | `color_separator`  |
 | Separator/dim  | Dim          | `color_separator`      | —                  |
 
 ### Base Colors

--- a/examples/statusline.conf
+++ b/examples/statusline.conf
@@ -229,10 +229,15 @@ color_separator=dim
 # Each structural element can also be colored independently. When unset, they
 # inherit color_separator above. Uncomment to give any of them its own color
 # (named colors or #rrggbb), so every value in the statusline can be distinct.
-# color_tps=#6ED7D2        # model throughput (e.g. "42.5 tok/s")
-# color_delta=#FFF8DC      # token delta since last refresh (e.g. "+2,500")
-# color_model=#C0C0C0      # model name (e.g. "Opus 4.8")
-# color_session=#8B8682    # session ID shown at the end
+# Keep the value alone on the line — trailing inline comments are not stripped.
+# model throughput (e.g. "42.5 tok/s")
+# color_tps=#6ED7D2
+# token delta since last refresh (e.g. "+2,500")
+# color_delta=#FFF8DC
+# model name (e.g. "Opus 4.8")
+# color_model=#C0C0C0
+# session ID shown at the end
+# color_session=#8B8682
 
 
 # ─── Statusline Layout Reference ────────────────────────────────────────────

--- a/examples/statusline.conf
+++ b/examples/statusline.conf
@@ -222,9 +222,17 @@ color_mi_score=#ff9e64
 # When not set, uses zone traffic-light color automatically.
 # color_zone=bright_green
 
-# Structural elements: model name, token delta, session ID.
+# Structural elements: tok/s, token delta, model name, session ID.
 # "dim" makes these visually recede so primary info stands out.
 color_separator=dim
+
+# Each structural element can also be colored independently. When unset, they
+# inherit color_separator above. Uncomment to give any of them its own color
+# (named colors or #rrggbb), so every value in the statusline can be distinct.
+# color_tps=#6ED7D2        # model throughput (e.g. "42.5 tok/s")
+# color_delta=#FFF8DC      # token delta since last refresh (e.g. "+2,500")
+# color_model=#C0C0C0      # model name (e.g. "Opus 4.8")
+# color_session=#8B8682    # session ID shown at the end
 
 
 # ─── Statusline Layout Reference ────────────────────────────────────────────

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -381,6 +381,10 @@ _COLOR_KEYS = {
     "color_mi_score": "mi_score",
     "color_zone": "zone",
     "color_separator": "separator",
+    "color_tps": "tps",
+    "color_delta": "delta",
+    "color_model": "model",
+    "color_session": "session",
 }
 
 # Zone threshold config keys (integer token counts)
@@ -806,9 +810,17 @@ color_mi_score=#ff9e64
 # When not set, uses zone traffic-light color automatically.
 # color_zone=bright_green
 
-# Structural elements: model name, token delta, session ID.
+# Structural elements: tok/s, token delta, model name, session ID.
 # "dim" makes these visually recede so primary info stands out.
 color_separator=dim
+
+# Each structural element can also be colored independently. When unset, they
+# inherit color_separator above. Uncomment to give any of them its own color
+# (named colors or #rrggbb), so every value in the statusline can be distinct.
+# color_tps=#6ED7D2        # model throughput (e.g. "42.5 tok/s")
+# color_delta=#FFF8DC      # token delta since last refresh (e.g. "+2,500")
+# color_model=#C0C0C0      # model name (e.g. "Opus 4.8")
+# color_session=#8B8682    # session ID shown at the end
 
 
 # ─── Statusline Layout Reference ────────────────────────────────────────────
@@ -1034,6 +1046,13 @@ def main():
     c_branch_name = c.get("branch_name", c_magenta if "magenta" in c else GREEN)
     c_separator = c.get("separator", DIM)
 
+    # Structural elements default to the separator color, but each can be
+    # overridden independently (color_tps / color_delta / color_model / color_session).
+    c_tps = c.get("tps", c_separator)
+    c_delta = c.get("delta", c_separator)
+    c_model = c.get("model", c_separator)
+    c_session = c.get("session", c_separator)
+
     # Git info (use per-property branch color, fallback to green)
     git_info = get_git_info(project_dir, magenta=c_branch_name, cyan=c_cyan)
 
@@ -1197,7 +1216,7 @@ def main():
                         delta_display = f"{delta:,}"
                     else:
                         delta_display = f"{delta / 1000:.1f}k"
-                    delta_info = f" | {c_separator}+{delta_display}{RESET}"
+                    delta_info = f" | {c_delta}+{delta_display}{RESET}"
 
             # Calculate and display MI score if enabled
             if show_mi:
@@ -1217,7 +1236,7 @@ def main():
                 tps = compute_tps(samples, window=tps_window)
                 if tps is not None:
                     tps_display = format_tps(tps, tps_precision, tps_unit)
-                    tps_info = f" | {c_separator}{tps_display}{RESET}"
+                    tps_info = f" | {c_tps}{tps_display}{RESET}"
 
             # Only append if context usage changed (avoid duplicates from multiple refreshes)
             if not has_prev or used_tokens != prev_tokens:
@@ -1252,16 +1271,16 @@ def main():
 
     # Display session_id if enabled
     if show_session and session_id:
-        session_info = f" | {c_separator}{session_id}{RESET}"
+        session_info = f" | {c_session}{session_id}{RESET}"
 
     # Output: dir | branch [changes] | XXk free (XX%) | zone | MI | tok/s | +delta | [Model] [id]
     # Model name is lowest priority — truncated first when terminal is narrow
     base = f"{c_project_name}{dir_name}{RESET}"
     thinking_text = _format_thinking_info(thinking_budget)
     if thinking_text:
-        model_info = f" | {c_separator}{model} · {thinking_text}{RESET}"
+        model_info = f" | {c_model}{model} · {thinking_text}{RESET}"
     else:
-        model_info = f" | {c_separator}{model}{RESET}"
+        model_info = f" | {c_model}{model}{RESET}"
     max_width = get_terminal_width()
     parts = [
         base,

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -817,10 +817,15 @@ color_separator=dim
 # Each structural element can also be colored independently. When unset, they
 # inherit color_separator above. Uncomment to give any of them its own color
 # (named colors or #rrggbb), so every value in the statusline can be distinct.
-# color_tps=#6ED7D2        # model throughput (e.g. "42.5 tok/s")
-# color_delta=#FFF8DC      # token delta since last refresh (e.g. "+2,500")
-# color_model=#C0C0C0      # model name (e.g. "Opus 4.8")
-# color_session=#8B8682    # session ID shown at the end
+# Keep the value alone on the line — trailing inline comments are not stripped.
+# model throughput (e.g. "42.5 tok/s")
+# color_tps=#6ED7D2
+# token delta since last refresh (e.g. "+2,500")
+# color_delta=#FFF8DC
+# model name (e.g. "Opus 4.8")
+# color_model=#C0C0C0
+# session ID shown at the end
+# color_session=#8B8682
 
 
 # ─── Statusline Layout Reference ────────────────────────────────────────────

--- a/src/claude_statusline/cli/statusline.py
+++ b/src/claude_statusline/cli/statusline.py
@@ -257,7 +257,7 @@ def main() -> None:
                 delta = used_tokens - prev_tokens
                 if has_prev and delta > 0:
                     delta_display = format_tokens(delta, config.token_detail)
-                    delta_info = f" | {colors.separator}+{delta_display}{colors.reset}"
+                    delta_info = f" | {colors.delta}+{delta_display}{colors.reset}"
 
             # Calculate MI score — pure function of utilization, no prev entry needed
             if config.show_mi:
@@ -286,7 +286,7 @@ def main() -> None:
                 tps = compute_tps(samples, window=config.tps_window)
                 if tps is not None:
                     tps_display = format_tps(tps, config.tps_precision, config.tps_unit)
-                    tps_info = f" | {colors.separator}{tps_display}{colors.reset}"
+                    tps_info = f" | {colors.tps}{tps_display}{colors.reset}"
 
             # Only append if context usage changed (avoid duplicates)
             if not has_prev or used_tokens != prev_tokens:
@@ -294,16 +294,16 @@ def main() -> None:
 
     # Display session_id if enabled
     if config.show_session and session_id:
-        session_info = f" | {colors.separator}{session_id}{colors.reset}"
+        session_info = f" | {colors.session}{session_id}{colors.reset}"
 
     # Output: directory | branch [changes] | XXk free (XX%) | zone | MI | +delta | [Model] [session_id]
     # Model name is lowest priority — truncated first when terminal is narrow
     base = f"{colors.project_name}{dir_name}{colors.reset}"
     thinking_text = _format_thinking_info(thinking_budget)
     if thinking_text:
-        model_info = f" | {colors.separator}{model} · {thinking_text}{colors.reset}"
+        model_info = f" | {colors.model}{model} · {thinking_text}{colors.reset}"
     else:
-        model_info = f" | {colors.separator}{model}{colors.reset}"
+        model_info = f" | {colors.model}{model}{colors.reset}"
     max_width = get_terminal_width()
     parts = [
         base,

--- a/src/claude_statusline/core/colors.py
+++ b/src/claude_statusline/core/colors.py
@@ -149,6 +149,32 @@ class ColorManager:
     def separator(self) -> str:
         return self._get("separator", DIM if self.enabled else "")
 
+    def _get_structural(self, slot: str) -> str:
+        """Structural elements default to the separator color, but each can be
+        overridden independently (color_tps / color_delta / color_model /
+        color_session)."""
+        if not self.enabled:
+            return ""
+        if slot in self._overrides:
+            return self._overrides[slot]
+        return self.separator
+
+    @property
+    def tps(self) -> str:
+        return self._get_structural("tps")
+
+    @property
+    def delta(self) -> str:
+        return self._get_structural("delta")
+
+    @property
+    def model(self) -> str:
+        return self._get_structural("model")
+
+    @property
+    def session(self) -> str:
+        return self._get_structural("session")
+
     @property
     def bold(self) -> str:
         return BOLD if self.enabled else ""

--- a/src/claude_statusline/core/config.py
+++ b/src/claude_statusline/core/config.py
@@ -25,6 +25,10 @@ _COLOR_KEYS: dict[str, str] = {
     "color_mi_score": "mi_score",
     "color_zone": "zone",
     "color_separator": "separator",
+    "color_tps": "tps",
+    "color_delta": "delta",
+    "color_model": "model",
+    "color_session": "session",
 }
 
 # Zone threshold config keys (integer token counts)

--- a/src/claude_statusline/data/statusline.conf.default
+++ b/src/claude_statusline/data/statusline.conf.default
@@ -229,10 +229,15 @@ color_separator=dim
 # Each structural element can also be colored independently. When unset, they
 # inherit color_separator above. Uncomment to give any of them its own color
 # (named colors or #rrggbb), so every value in the statusline can be distinct.
-# color_tps=#6ED7D2        # model throughput (e.g. "42.5 tok/s")
-# color_delta=#FFF8DC      # token delta since last refresh (e.g. "+2,500")
-# color_model=#C0C0C0      # model name (e.g. "Opus 4.8")
-# color_session=#8B8682    # session ID shown at the end
+# Keep the value alone on the line — trailing inline comments are not stripped.
+# model throughput (e.g. "42.5 tok/s")
+# color_tps=#6ED7D2
+# token delta since last refresh (e.g. "+2,500")
+# color_delta=#FFF8DC
+# model name (e.g. "Opus 4.8")
+# color_model=#C0C0C0
+# session ID shown at the end
+# color_session=#8B8682
 
 
 # ─── Statusline Layout Reference ────────────────────────────────────────────

--- a/src/claude_statusline/data/statusline.conf.default
+++ b/src/claude_statusline/data/statusline.conf.default
@@ -222,9 +222,17 @@ color_mi_score=#ff9e64
 # When not set, uses zone traffic-light color automatically.
 # color_zone=bright_green
 
-# Structural elements: model name, token delta, session ID.
+# Structural elements: tok/s, token delta, model name, session ID.
 # "dim" makes these visually recede so primary info stands out.
 color_separator=dim
+
+# Each structural element can also be colored independently. When unset, they
+# inherit color_separator above. Uncomment to give any of them its own color
+# (named colors or #rrggbb), so every value in the statusline can be distinct.
+# color_tps=#6ED7D2        # model throughput (e.g. "42.5 tok/s")
+# color_delta=#FFF8DC      # token delta since last refresh (e.g. "+2,500")
+# color_model=#C0C0C0      # model name (e.g. "Opus 4.8")
+# color_session=#8B8682    # session ID shown at the end
 
 
 # ─── Statusline Layout Reference ────────────────────────────────────────────

--- a/tests/python/test_colors.py
+++ b/tests/python/test_colors.py
@@ -103,3 +103,50 @@ class TestColorManager:
         cm = ColorManager(enabled=True, overrides={"bold": "custom"})
         # bold is not in the _get path, it uses the hardcoded value
         assert cm.bold == "\033[1m"
+
+
+class TestStructuralColors:
+    """Tests for per-element structural colors (tps, delta, model, session).
+
+    Each defaults to the separator color but can be overridden independently.
+    """
+
+    STRUCTURAL = ("tps", "delta", "model", "session")
+
+    def test_default_to_separator(self):
+        """Without overrides, each structural element inherits the separator color."""
+        cm = ColorManager(enabled=True)
+        for slot in self.STRUCTURAL:
+            assert getattr(cm, slot) == cm.separator
+
+    def test_inherit_overridden_separator(self):
+        """When separator is overridden but the element is not, it follows separator."""
+        custom = "\033[38;2;1;2;3m"
+        cm = ColorManager(enabled=True, overrides={"separator": custom})
+        for slot in self.STRUCTURAL:
+            assert getattr(cm, slot) == custom
+
+    def test_override_each_independently(self):
+        overrides = {
+            "tps": "\033[38;2;110;215;210m",
+            "delta": "\033[38;2;255;248;220m",
+            "model": "\033[38;2;192;192;192m",
+            "session": "\033[38;2;139;134;130m",
+        }
+        cm = ColorManager(enabled=True, overrides=overrides)
+        for slot, code in overrides.items():
+            assert getattr(cm, slot) == code
+
+    def test_one_override_does_not_affect_others(self):
+        """Overriding model leaves tps/delta/session on the separator default."""
+        custom = "\033[38;2;192;192;192m"
+        cm = ColorManager(enabled=True, overrides={"model": custom})
+        assert cm.model == custom
+        assert cm.tps == cm.separator
+        assert cm.delta == cm.separator
+        assert cm.session == cm.separator
+
+    def test_disabled_returns_empty(self):
+        cm = ColorManager(enabled=False, overrides={"model": "\033[38;2;1;1;1m"})
+        for slot in self.STRUCTURAL:
+            assert getattr(cm, slot) == ""

--- a/tests/python/test_config_colors.py
+++ b/tests/python/test_config_colors.py
@@ -79,6 +79,21 @@ class TestConfigColorOverrides:
         config = Config.load(config_path=config_file)
         assert len(config.color_overrides) == 6
 
+    def test_structural_color_slots(self, tmp_path):
+        """color_tps/delta/model/session map to their own override slots."""
+        config_file = tmp_path / "statusline.conf"
+        config_file.write_text(
+            "color_tps=#6ED7D2\n"
+            "color_delta=#FFF8DC\n"
+            "color_model=#C0C0C0\n"
+            "color_session=#8B8682\n"
+        )
+        config = Config.load(config_path=config_file)
+        assert config.color_overrides["tps"] == "\033[38;2;110;215;210m"
+        assert config.color_overrides["delta"] == "\033[38;2;255;248;220m"
+        assert config.color_overrides["model"] == "\033[38;2;192;192;192m"
+        assert config.color_overrides["session"] == "\033[38;2;139;134;130m"
+
 
 class TestConfigDefaultRoundTrip:
     """Tests that the default config template can be written and read back."""

--- a/tests/python/test_config_colors.py
+++ b/tests/python/test_config_colors.py
@@ -83,10 +83,7 @@ class TestConfigColorOverrides:
         """color_tps/delta/model/session map to their own override slots."""
         config_file = tmp_path / "statusline.conf"
         config_file.write_text(
-            "color_tps=#6ED7D2\n"
-            "color_delta=#FFF8DC\n"
-            "color_model=#C0C0C0\n"
-            "color_session=#8B8682\n"
+            "color_tps=#6ED7D2\ncolor_delta=#FFF8DC\ncolor_model=#C0C0C0\ncolor_session=#8B8682\n"
         )
         config = Config.load(config_path=config_file)
         assert config.color_overrides["tps"] == "\033[38;2;110;215;210m"


### PR DESCRIPTION
## Summary

Adds four optional config keys so each structural element of the statusline can be colored independently:

- `color_tps` — model throughput (e.g. `42.5 tok/s`)
- `color_delta` — token delta since last refresh (e.g. `+2,500`)
- `color_model` — model name (e.g. `Opus 4.8`)
- `color_session` — session ID shown at the end

Previously these four all shared `color_separator` with no way to distinguish them. Each new key **defaults to `color_separator` when unset**, so existing configs render identically — this is purely additive.

## Changes

- **`core/colors.py`** — new `tps`/`delta`/`model`/`session` properties backed by a shared `_get_structural` helper that falls back to `separator`.
- **`core/config.py`** + **`scripts/statusline.py`** — register the four new color keys (kept in sync per the package/standalone sync-point contract).
- **`cli/statusline.py`** + **`scripts/statusline.py`** — render each segment with its per-element color instead of `separator`.
- **docs / examples / default config** — document the new keys and the fallback-to-`color_separator` behavior.
- **tests** — cover default-to-separator, inheriting an overridden separator, independent overrides, single-override isolation, and disabled behavior, plus config-parsing of the new keys.

## Testing

`pytest tests/python/ -v` — **542 passed**.


Closes #86
